### PR TITLE
feat: Support parent/sibling navigation

### DIFF
--- a/src/ops/tree/tui/state.rs
+++ b/src/ops/tree/tui/state.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
-use crossterm::event::{KeyCode, KeyEvent};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::core::DependencyTree;
 
@@ -27,27 +27,38 @@ impl TuiState {
     }
 
     pub fn handle_key_event(&mut self, key_event: KeyEvent) {
-        match key_event.code {
-            KeyCode::Char('q') => {
+        match (key_event.code, key_event.modifiers) {
+            (KeyCode::Char('q'), _) => {
                 self.running = false;
             }
-            KeyCode::Down => {
+            (KeyCode::Char('p'), _) => {
+                self.tree_widget_state.select_parent(&self.dependency_tree);
+            }
+            (KeyCode::Down, mods) if mods.contains(KeyModifiers::CONTROL) => {
+                self.tree_widget_state
+                    .select_next_sibling(&self.dependency_tree);
+            }
+            (KeyCode::Up, mods) if mods.contains(KeyModifiers::CONTROL) => {
+                self.tree_widget_state
+                    .select_previous_sibling(&self.dependency_tree);
+            }
+            (KeyCode::Down, _) => {
                 self.tree_widget_state.select_next(&self.dependency_tree);
             }
-            KeyCode::Up => {
+            (KeyCode::Up, _) => {
                 self.tree_widget_state
                     .select_previous(&self.dependency_tree);
             }
-            KeyCode::PageDown => {
+            (KeyCode::PageDown, _) => {
                 self.tree_widget_state.page_down(&self.dependency_tree);
             }
-            KeyCode::PageUp => {
+            (KeyCode::PageUp, _) => {
                 self.tree_widget_state.page_up(&self.dependency_tree);
             }
-            KeyCode::Right => {
+            (KeyCode::Right, _) => {
                 self.tree_widget_state.expand(&self.dependency_tree);
             }
-            KeyCode::Left => {
+            (KeyCode::Left, _) => {
                 self.tree_widget_state.collapse(&self.dependency_tree);
             }
             _ => {}

--- a/src/ops/tree/tui/widget_state.rs
+++ b/src/ops/tree/tui/widget_state.rs
@@ -114,6 +114,69 @@ impl TreeWidgetState {
         }
     }
 
+    /// Moves the selection to the parent node, if any.
+    pub fn select_parent(&mut self, tree: &DependencyTree) {
+        let Some(selected) = self.selected else {
+            return;
+        };
+
+        if let Some(node) = tree.node(selected)
+            && let Some(parent) = node.parent
+        {
+            self.selected = Some(parent);
+        }
+    }
+
+    /// Moves the selection to the next sibling, if any.
+    pub fn select_next_sibling(&mut self, tree: &DependencyTree) {
+        let Some(selected) = self.selected else {
+            return;
+        };
+        let Some(node) = tree.node(selected) else {
+            return;
+        };
+
+        let Some(parent) = node.parent else {
+            return;
+        };
+        let Some(parent_node) = tree.node(parent) else {
+            return;
+        };
+
+        let Some(pos) = parent_node.children.iter().position(|&id| id == selected) else {
+            return;
+        };
+
+        if pos + 1 < parent_node.children.len() {
+            self.selected = Some(parent_node.children[pos + 1]);
+        }
+    }
+
+    /// Moves the selection to the previous sibling, if any.
+    pub fn select_previous_sibling(&mut self, tree: &DependencyTree) {
+        let Some(selected) = self.selected else {
+            return;
+        };
+        let Some(node) = tree.node(selected) else {
+            return;
+        };
+
+        let Some(parent) = node.parent else {
+            return;
+        };
+        let Some(parent_node) = tree.node(parent) else {
+            return;
+        };
+
+        let Some(pos) = parent_node.children.iter().position(|&id| id == selected) else {
+            return;
+        };
+
+        if pos > 0 {
+            self.selected = Some(parent_node.children[pos - 1]);
+        }
+    }
+
     /// Moves the selection up by approximately one page.
     pub fn page_up(&mut self, tree: &DependencyTree) {
         let step = self.viewport.height.saturating_sub(1).max(1) as isize;


### PR DESCRIPTION
- Use C-up and C-down to move between siblings.
- Use P to move to the parent node.
