### PR TITLE
feat: add help bar

### DIFF
--- a/src/ops/tree/tui/mod.rs
+++ b/src/ops/tree/tui/mod.rs
@@ -4,13 +4,17 @@ pub mod widget_state;
 
 use ratatui::{
     Frame,
-    widgets::{Block, Scrollbar, ScrollbarOrientation},
+    layout::{Constraint, Layout},
+    widgets::{Block, Paragraph, Scrollbar, ScrollbarOrientation},
 };
 
 use state::TuiState;
 use widget::TreeWidget;
 
 pub fn draw_tui(frame: &mut Frame, state: &mut TuiState) {
+    let layout = Layout::vertical([Constraint::Min(0), Constraint::Length(1)])
+        .split(frame.area());
+
     let tree_widget = TreeWidget::new(&state.dependency_tree)
         .block(Block::bordered())
         .scrollbar(
@@ -18,5 +22,8 @@ pub fn draw_tui(frame: &mut Frame, state: &mut TuiState) {
                 .begin_symbol(Some("↑"))
                 .end_symbol(Some("↓")),
         );
-    frame.render_stateful_widget(tree_widget, frame.area(), &mut state.tree_widget_state);
+    frame.render_stateful_widget(tree_widget, layout[0], &mut state.tree_widget_state);
+
+    let help = Paragraph::new("←/→ expand/collapse | ↑/↓ navigate | PgUp/PgDn scroll | q quit");
+    frame.render_widget(help, layout[1]);
 }


### PR DESCRIPTION
Added a simple help text showing: ←/→ expand/collapse | ↑/↓ navigate | PgUp/PgDn scroll | q quit