### PR TITLE
Added basic vim navigation (j and k) for navigating the tree

### DIFF
--- a/src/ops/tree/tui/state.rs
+++ b/src/ops/tree/tui/state.rs
@@ -55,10 +55,10 @@ impl TuiState {
                 self.tree_widget_state
                     .select_previous_sibling(&self.dependency_tree);
             }
-            (KeyCode::Down, _) => {
+            (KeyCode::Down | KeyCode::Char('j'), _) => {
                 self.tree_widget_state.select_next(&self.dependency_tree);
             }
-            (KeyCode::Up, _) => {
+            (KeyCode::Up | KeyCode::Char('k'), _) => {
                 self.tree_widget_state
                     .select_previous(&self.dependency_tree);
             }


### PR DESCRIPTION
This PR adds `j` and `k` for down and up respectively to match vim style navigation.