### PR TITLE
refactor(core): replace recursive dep loading with iterative pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16,6 +22,26 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "annotate-snippets"
+version = "0.12.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c86cd1c51b95d71dde52bca69ed225008f6ff4c8cc825b08042aa1ef823e1980"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width",
+]
 
 [[package]]
 name = "anstream"
@@ -53,7 +79,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -64,7 +90,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -72,6 +98,27 @@ name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "atomic"
@@ -89,10 +136,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bit-set"
@@ -122,12 +181,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "bitmaps"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "blake3"
+version = "1.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -143,12 +245,143 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
 
 [[package]]
-name = "camino"
-version = "1.2.1"
+name = "byteorder"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276a59bf2b2c967788139340c9f0c5b12d7fd6630315c15c217e559de85d2609"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cargo"
+version = "0.95.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0af45a75a5265a587a8d9e4098cd2b12a07b34bcbd9eb7952ae6a62ea6d65c4d"
 dependencies = [
- "serde_core",
+ "annotate-snippets",
+ "anstream",
+ "anstyle",
+ "anyhow",
+ "base64",
+ "blake3",
+ "cargo-credential",
+ "cargo-credential-libsecret",
+ "cargo-credential-macos-keychain",
+ "cargo-credential-wincred",
+ "cargo-platform",
+ "cargo-util",
+ "cargo-util-schemas",
+ "clap",
+ "clap_complete",
+ "color-print",
+ "crates-io",
+ "curl",
+ "curl-sys",
+ "filetime",
+ "flate2",
+ "git2",
+ "git2-curl",
+ "gix",
+ "glob",
+ "hex",
+ "hmac",
+ "home",
+ "http-auth",
+ "ignore",
+ "im-rc",
+ "indexmap",
+ "itertools 0.14.0",
+ "jiff",
+ "jobserver",
+ "libc",
+ "libgit2-sys",
+ "memchr",
+ "opener",
+ "os_info",
+ "pasetors",
+ "pathdiff",
+ "rand 0.9.2",
+ "regex",
+ "rusqlite",
+ "rustc-hash",
+ "rustc-stable-hash",
+ "rustfix",
+ "same-file",
+ "semver",
+ "serde",
+ "serde-untagged",
+ "serde_ignored",
+ "serde_json",
+ "sha1",
+ "shell-escape",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "tar",
+ "tempfile",
+ "thiserror 2.0.17",
+ "time",
+ "toml",
+ "toml_edit",
+ "tracing",
+ "tracing-chrome",
+ "tracing-subscriber",
+ "unicase",
+ "unicode-ident",
+ "unicode-width",
+ "url",
+ "walkdir",
+ "windows-sys 0.61.2",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "cargo-credential"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e36f089041deadf16226478a7737a833864fbda09408c7af237b9d615eeb6d69"
+dependencies = [
+ "anyhow",
+ "libc",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "time",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "cargo-credential-libsecret"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6f199366cecd4e86e3db8c16d4054ea3c53287250a18190929f74be26bb8642"
+dependencies = [
+ "anyhow",
+ "cargo-credential",
+ "libloading",
+]
+
+[[package]]
+name = "cargo-credential-macos-keychain"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf99df49467cac5cc000b9134f4faf9ecc54484462d314ce605ff6e19c523f90"
+dependencies = [
+ "cargo-credential",
+ "security-framework",
+]
+
+[[package]]
+name = "cargo-credential-wincred"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9be5164881738c558a89fd0fd25cdda82a587dab6d2616e4a3ba0c9069a29c35"
+dependencies = [
+ "cargo-credential",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -165,7 +398,8 @@ name = "cargo-tree-tui"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "cargo_metadata",
+ "cargo",
+ "cargo-util",
  "clap",
  "clap-cargo",
  "compact_str",
@@ -177,17 +411,43 @@ dependencies = [
 ]
 
 [[package]]
-name = "cargo_metadata"
-version = "0.23.1"
+name = "cargo-util"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
+checksum = "4a4b72539a4e322539ac3cd07d7e63d60ca3823f3143a2d39a9f8fcdace0e8ca"
 dependencies = [
- "camino",
- "cargo-platform",
+ "anyhow",
+ "core-foundation",
+ "filetime",
+ "hex",
+ "ignore",
+ "jobserver",
+ "libc",
+ "miow",
+ "same-file",
+ "sha2",
+ "shell-escape",
+ "tempfile",
+ "tracing",
+ "walkdir",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "cargo-util-schemas"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74b5c24ba23f6d05b6cb15946d08bb6dd61b96ae920f17b33b17d4e7b1e76555"
+dependencies = [
+ "jiff",
  "semver",
  "serde",
- "serde_json",
+ "serde-untagged",
+ "serde-value",
  "thiserror 2.0.17",
+ "toml",
+ "unicode-ident",
+ "url",
 ]
 
 [[package]]
@@ -197,6 +457,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -239,8 +511,21 @@ checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex",
+ "clap_lex 0.7.6",
  "strsim",
+ "terminal_size",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
+dependencies = [
+ "clap",
+ "clap_lex 1.1.0",
+ "is_executable",
+ "shlex",
 ]
 
 [[package]]
@@ -260,6 +545,42 @@ name = "clap_lex"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "clru"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "color-print"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aa954171903797d5623e047d9ab69d91b493657917bdfb8c2c80ecaf9cdb6f4"
+dependencies = [
+ "color-print-proc-macro",
+]
+
+[[package]]
+name = "color-print-proc-macro"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692186b5ebe54007e45a59aea47ece9eb4108e141326c304cdc91699a7118a22"
+dependencies = [
+ "nom",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
+]
 
 [[package]]
 name = "colorchoice"
@@ -282,6 +603,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
 name = "convert_case"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,6 +624,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,6 +647,72 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crates-io"
+version = "0.40.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec97b1f074b7b2fe478fb89e51a26e25a75ae2de02d4c8cc85c5f206dd628286"
+dependencies = [
+ "curl",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "url",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
@@ -327,6 +742,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,6 +771,43 @@ checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
  "phf",
+]
+
+[[package]]
+name = "ct-codecs"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b10589d1a5e400d61f9f38f12f884cfd080ff345de8f17efda36fe0e4a02aa8"
+
+[[package]]
+name = "curl"
+version = "0.4.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79fc3b6dd0b87ba36e565715bf9a2ced221311db47bd18011676f24a6066edbc"
+dependencies = [
+ "curl-sys",
+ "libc",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "socket2",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "curl-sys"
+version = "0.4.87+curl-8.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61a460380f0ef783703dcbe909107f39c162adeac050d73c850055118b5b6327"
+dependencies = [
+ "cc",
+ "libc",
+ "libnghttp2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -382,10 +846,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
 
 [[package]]
 name = "deranged"
@@ -394,6 +883,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -430,7 +920,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -443,10 +956,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519-compact"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ce99a9e19c84beb4cc35ece85374335ccc398240712114c85038319ed709bd"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "equivalent"
@@ -455,13 +1027,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -474,6 +1057,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fancy-regex"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,6 +1077,38 @@ dependencies = [
  "bit-set",
  "regex",
 ]
+
+[[package]]
+name = "faster-hex"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
+dependencies = [
+ "heapless",
+ "serde",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "filedescriptor"
@@ -493,6 +1120,23 @@ dependencies = [
  "thiserror 1.0.69",
  "winapi",
 ]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "finl_unicode"
@@ -507,6 +1151,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "miniz_oxide",
+ "zlib-rs 0.6.3",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,9 +1168,24 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "generic-array"
@@ -526,6 +1195,18 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -535,9 +1216,904 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "git2"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+dependencies = [
+ "bitflags 2.10.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
+
+[[package]]
+name = "git2-curl"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8dcabbc09ece4d30a9aa983d5804203b7e2f8054a171f792deff59b56d31fa"
+dependencies = [
+ "curl",
+ "git2",
+ "log",
+ "url",
+]
+
+[[package]]
+name = "gix"
+version = "0.77.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d8284d86a2f5c0987fbf7219a128815cc04af5a18f5fd7eec6a76d83c2b78cc"
+dependencies = [
+ "gix-actor",
+ "gix-attributes",
+ "gix-command",
+ "gix-commitgraph",
+ "gix-config",
+ "gix-credentials",
+ "gix-date",
+ "gix-diff",
+ "gix-dir",
+ "gix-discover",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-ignore",
+ "gix-index",
+ "gix-lock",
+ "gix-negotiate",
+ "gix-object",
+ "gix-odb",
+ "gix-pack",
+ "gix-path",
+ "gix-pathspec",
+ "gix-prompt",
+ "gix-protocol",
+ "gix-ref",
+ "gix-refspec",
+ "gix-revision",
+ "gix-revwalk",
+ "gix-sec",
+ "gix-shallow",
+ "gix-status",
+ "gix-submodule",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-transport",
+ "gix-traverse",
+ "gix-url",
+ "gix-utils",
+ "gix-validate",
+ "gix-worktree",
+ "prodash",
+ "smallvec",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-actor"
+version = "0.37.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c345528d405eab51d20f505f5fe1a4680973953694e0292c6bbe97827daa55c4"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-utils",
+ "itoa",
+ "thiserror 2.0.17",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "gix-attributes"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47dabf8a50f1558c3a55d978440c7c4f22f87ac897bef03b4edbc96f6115966"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "kstring",
+ "smallvec",
+ "thiserror 2.0.17",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-bitmap"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e150161b8a75b5860521cb876b506879a3376d3adc857ec7a9d35e7c6a5e531"
+dependencies = [
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-chunk"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c356b3825677cb6ff579551bb8311a81821e184453cbd105e2fc5311b288eeb"
+dependencies = [
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-command"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46f9c425730a654835351e6da8c3c69ba1804f8b8d4e96d027254151138d5c64"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "shell-words",
+]
+
+[[package]]
+name = "gix-commitgraph"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efdcba8048045baf15225daf949d597c3e6183d130245e22a7fbd27084abe63a"
+dependencies = [
+ "bstr",
+ "gix-chunk",
+ "gix-hash",
+ "memmap2",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-config"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b58e2ff8eef96b71f2c5e260f02ca0475caff374027c5cc5a29bda69fac67404"
+dependencies = [
+ "bstr",
+ "gix-config-value",
+ "gix-features",
+ "gix-glob",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "memchr",
+ "smallvec",
+ "thiserror 2.0.17",
+ "unicode-bom",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "gix-config-value"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2409cffa4fe8b303847d5b6ba8df9da9ba65d302fc5ee474ea0cac5afde79840"
+dependencies = [
+ "bitflags 2.10.0",
+ "bstr",
+ "gix-path",
+ "libc",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-credentials"
+version = "0.34.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "316a12842fb761a7a6e9ae963d7bae9f0f4c433f242282df91192ef084b1891c"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-config-value",
+ "gix-date",
+ "gix-path",
+ "gix-prompt",
+ "gix-sec",
+ "gix-trace",
+ "gix-url",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-date"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4a31bab8159e233094fa70d2e5fd3ec6f19e593f67e6ae01281daa48f8d8e7"
+dependencies = [
+ "bstr",
+ "itoa",
+ "jiff",
+ "smallvec",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-diff"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3506936e63ce14cd54b5f28ed06c8e43b92ef9f41c2238cc0bc271a9259b4e90"
+dependencies = [
+ "bstr",
+ "gix-attributes",
+ "gix-command",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-traverse",
+ "gix-worktree",
+ "imara-diff",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-dir"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709d9fad32d2eb8b0129850874246569e801b6d5877e0c41356c23e9e2501e06"
+dependencies = [
+ "bstr",
+ "gix-discover",
+ "gix-fs",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-trace",
+ "gix-utils",
+ "gix-worktree",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-discover"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ce096dc132533802a09d6fd5d4008858f2038341dfe2e69e0d0239edb359de"
+dependencies = [
+ "bstr",
+ "dunce",
+ "gix-fs",
+ "gix-hash",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-features"
+version = "0.45.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56aad357ae016449434705033df644ac6253dfcf1281aad3af3af9e907560d1"
+dependencies = [
+ "bytes",
+ "crc32fast",
+ "crossbeam-channel",
+ "gix-path",
+ "gix-trace",
+ "gix-utils",
+ "libc",
+ "once_cell",
+ "parking_lot",
+ "prodash",
+ "thiserror 2.0.17",
+ "walkdir",
+ "zlib-rs 0.5.5",
+]
+
+[[package]]
+name = "gix-filter"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10c02464962482570c1f94ad451a608c4391514f803e8074662d02c5629a25dc"
+dependencies = [
+ "bstr",
+ "encoding_rs",
+ "gix-attributes",
+ "gix-command",
+ "gix-hash",
+ "gix-object",
+ "gix-packetline",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "gix-utils",
+ "smallvec",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-fs"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "785b9c499e46bc78d7b81c148c21b3fca18655379ee729a856ed19ce50d359ec"
+dependencies = [
+ "bstr",
+ "fastrand",
+ "gix-features",
+ "gix-path",
+ "gix-utils",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-glob"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8546300aee4c65c5862c22a3e321124a69b654a61a8b60de546a9284812b7e2"
+dependencies = [
+ "bitflags 2.10.0",
+ "bstr",
+ "gix-features",
+ "gix-path",
+]
+
+[[package]]
+name = "gix-hash"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e153930f42ccdab8a3306b1027cd524879f6a8996cd0c474d18b0e56cae7714d"
+dependencies = [
+ "faster-hex",
+ "gix-features",
+ "sha1-checked",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-hashtable"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222f7428636020bef272a87ed833ea48bf5fb3193f99852ae16fbb5a602bd2f0"
+dependencies = [
+ "gix-hash",
+ "hashbrown 0.16.1",
+ "parking_lot",
+]
+
+[[package]]
+name = "gix-ignore"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa727fdf54fd9fb53fa3fbb1a5c17172d3073e8e336bf155f3cac3e25b81b21"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-trace",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-index"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea6d3e9e11647ba49f441dea0782494cc6d2875ff43fa4ad9094e6957f42051"
+dependencies = [
+ "bitflags 2.10.0",
+ "bstr",
+ "filetime",
+ "fnv",
+ "gix-bitmap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-traverse",
+ "gix-utils",
+ "gix-validate",
+ "hashbrown 0.16.1",
+ "itoa",
+ "libc",
+ "memmap2",
+ "rustix",
+ "smallvec",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-lock"
+version = "20.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115268ae5e3b3b7bc7fc77260eecee05acca458e45318ca45d35467fa81a3ac5"
+dependencies = [
+ "gix-tempfile",
+ "gix-utils",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-negotiate"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cee7e32e6198e356caef0e4b8321bc2f9b2afeb76f870c0bf9aa05fe53edb6"
+dependencies = [
+ "bitflags 2.10.0",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
+ "smallvec",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-object"
+version = "0.54.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "363d6a879c52e4890180e0ffa7d8c9a364fd0b7e807caa368e860b80e8d0bc81"
+dependencies = [
+ "bstr",
+ "gix-actor",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-path",
+ "gix-utils",
+ "gix-validate",
+ "itoa",
+ "smallvec",
+ "thiserror 2.0.17",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "gix-odb"
+version = "0.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "165a907df369a12ed4330faf8baf7ae597aadb08cfacb4ed8649f93d90bcc0c5"
+dependencies = [
+ "arc-swap",
+ "gix-date",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-pack",
+ "gix-path",
+ "gix-quote",
+ "parking_lot",
+ "tempfile",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-pack"
+version = "0.64.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b04a73d5ab07ea0faae55e2c0ae6f24e36e365ac8ce140394dee3a2c89cd4366"
+dependencies = [
+ "clru",
+ "gix-chunk",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "memmap2",
+ "parking_lot",
+ "smallvec",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-packetline"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fad0ffb982a289888087a165d3e849cbac724f2aa5431236b050dd2cb9c7de31"
+dependencies = [
+ "bstr",
+ "faster-hex",
+ "gix-trace",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-path"
+version = "0.10.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cb06c3e4f8eed6e24fd915fa93145e28a511f4ea0e768bae16673e05ed3f366"
+dependencies = [
+ "bstr",
+ "gix-trace",
+ "gix-validate",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-pathspec"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9e0c881933c37a7ef45288d6c5779c4a7b3ad240b4c37657e1d9829eb90085"
+dependencies = [
+ "bitflags 2.10.0",
+ "bstr",
+ "gix-attributes",
+ "gix-config-value",
+ "gix-glob",
+ "gix-path",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-prompt"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "974b142ea650fb0050a301958f49c8cc68929c36f686e9606a381ce39da34fd9"
+dependencies = [
+ "gix-command",
+ "gix-config-value",
+ "parking_lot",
+ "rustix",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-protocol"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02c5dfd068789442c5709e702ef42d851765f2c09a11bf0a13749d24363f4d07"
+dependencies = [
+ "bstr",
+ "gix-credentials",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-lock",
+ "gix-negotiate",
+ "gix-object",
+ "gix-ref",
+ "gix-refspec",
+ "gix-revwalk",
+ "gix-shallow",
+ "gix-trace",
+ "gix-transport",
+ "gix-utils",
+ "maybe-async",
+ "thiserror 2.0.17",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "gix-quote"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e912ec04b7b1566a85ad486db0cab6b9955e3e32bcd3c3a734542ab3af084c5b"
+dependencies = [
+ "bstr",
+ "gix-utils",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-ref"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccb33aa97006e37e9e83fde233569a66b02ed16fd4b0406cdf35834b06cf8a63"
+dependencies = [
+ "gix-actor",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "gix-utils",
+ "gix-validate",
+ "memmap2",
+ "thiserror 2.0.17",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "gix-refspec"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbba6ae5389f4021f73a2d62a4195aace7db1e8bb684b25521d3d685f57da02"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-hash",
+ "gix-revision",
+ "gix-validate",
+ "smallvec",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-revision"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91898c83b18c635696f7355d171cfa74a52f38022ff89581f567768935ebc4c8"
+dependencies = [
+ "bstr",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-revwalk"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d063699278485016863d0d2bb0db7609fd2e8ba9a89379717bf06fd96949eb2"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "smallvec",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-sec"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea9962ed6d9114f7f100efe038752f41283c225bb507a2888903ac593dffa6be"
+dependencies = [
+ "bitflags 2.10.0",
+ "gix-path",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "gix-shallow"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c1c467fb9f7ec1d33613c2ea5482de514bcb84b8222a793cdc4c71955832356"
+dependencies = [
+ "bstr",
+ "gix-hash",
+ "gix-lock",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-status"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed0d94c685a831c679ca5454c22f350e8c233f50dcf377ca00d858bcba9696d2"
+dependencies = [
+ "bstr",
+ "filetime",
+ "gix-diff",
+ "gix-dir",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-worktree",
+ "portable-atomic",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-submodule"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efee2a61198413d80de10028aa507344537827d776ade781760130721bec2419"
+dependencies = [
+ "bstr",
+ "gix-config",
+ "gix-path",
+ "gix-pathspec",
+ "gix-refspec",
+ "gix-url",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-tempfile"
+version = "20.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad89218e74850f42d364ed3877c7291f0474c8533502df91bb877ecc5cb0dd40"
+dependencies = [
+ "dashmap",
+ "gix-fs",
+ "libc",
+ "parking_lot",
+ "tempfile",
+]
+
+[[package]]
+name = "gix-trace"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f69a13643b8437d4ca6845e08143e847a36ca82903eed13303475d0ae8b162e0"
+
+[[package]]
+name = "gix-transport"
+version = "0.52.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4d4ed02a2ebe771a26111896ecda0b98b58ed35e1d9c0ccf07251c1abb4918d"
+dependencies = [
+ "base64",
+ "bstr",
+ "curl",
+ "gix-command",
+ "gix-credentials",
+ "gix-features",
+ "gix-packetline",
+ "gix-quote",
+ "gix-sec",
+ "gix-url",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-traverse"
+version = "0.51.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d052b83d1d1744be95ac6448ac02f95f370a8f6720e466be9ce57146e39f5280"
+dependencies = [
+ "bitflags 2.10.0",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
+ "smallvec",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-url"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff1996dfb9430b3699d89224c674169c1ae355eacc52bf30a03c0b8bffe73d9"
+dependencies = [
+ "bstr",
+ "gix-features",
+ "gix-path",
+ "percent-encoding",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-utils"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "befcdbdfb1238d2854591f760a48711bed85e72d80a10e8f2f93f656746ef7c5"
+dependencies = [
+ "bstr",
+ "fastrand",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "gix-validate"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b1e63a5b516e970a594f870ed4571a8fdcb8a344e7bd407a20db8bd61dbfde4"
+dependencies = [
+ "bstr",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-worktree"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfb7ce8cdbfe06117d335d1ad329351468d20331e0aafd108ceb647c1326aca"
+dependencies = [
+ "bstr",
+ "gix-attributes",
+ "gix-features",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-validate",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -548,7 +2124,26 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -564,10 +2159,206 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "http-auth"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "150fa4a9462ef926824cf4519c84ed652ca8f4fbae34cb8af045b5cbcaf98822"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
+name = "im-rc"
+version = "15.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1955a75fa080c677d3972822ec4bad316169ab1cfc6c257a942c2265dbe5fe"
+dependencies = [
+ "bitmaps",
+ "rand_core 0.6.4",
+ "rand_xoshiro",
+ "sized-chunks",
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "imara-diff"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17d34b7d42178945f775e84bc4c36dde7c1c6cdfea656d3354d009056f2bb3d2"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "indoc"
@@ -589,6 +2380,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.110",
+]
+
+[[package]]
+name = "is_executable"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baabb8b4867b26294d818bf3f651a454b6901431711abb96e296245888d6e8c4"
+dependencies = [
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -617,9 +2417,60 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -637,9 +2488,18 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fe90c1150662e858c7d5f945089b7517b0a80d8bf7ba4b1b5ffc984e7230a5b"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.16.1",
  "portable-atomic",
  "thiserror 2.0.17",
+]
+
+[[package]]
+name = "kstring"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
+dependencies = [
+ "static_assertions",
 ]
 
 [[package]]
@@ -655,10 +2515,99 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.177"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.184"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.18.3+1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
+name = "libnghttp2-sys"
+version = "0.1.13+1.68.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "492e00167f1418c15648144f42bbfc63099806ecee9bf8d09a6353d6b4856b3c"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+dependencies = [
+ "bitflags 2.10.0",
+ "libc",
+ "plain",
+ "redox_syscall 0.7.3",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95b4103cffefa72eb8428cb6b47d6627161e51c2739fc5e3b734584157bc642a"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "line-clipping"
@@ -671,9 +2620,15 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -702,7 +2657,7 @@ version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -711,8 +2666,28 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
 dependencies = [
- "nix",
+ "nix 0.29.0",
  "winapi",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "maybe-async"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -720,6 +2695,15 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memmem"
@@ -743,6 +2727,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -751,7 +2745,16 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "miow"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -768,6 +2771,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,6 +2790,24 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "normpath"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf23ab2b905654b4cb177e30b629937b3868311d4e1cba859f899c041046e69b"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -813,6 +2846,165 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.10.0",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.10.0",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -825,12 +3017,87 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opener"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2fa337e0cf13357c13ef1dc108df1333eb192f75fc170bea03fcf1fd404c2ee"
+dependencies = [
+ "bstr",
+ "normpath",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.112"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "orion"
+version = "0.17.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fa7b8bd24f9f1b7fa56de934075adba4b6fb1bf0bf38db74f4236e05e14776"
+dependencies = [
+ "fiat-crypto",
+ "subtle",
+]
+
+[[package]]
+name = "os_info"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix 0.30.1",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
 ]
 
 [[package]]
@@ -851,10 +3118,53 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "pasetors"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e838401fb2873bad417e6a03179014c748746f67311cb7317ab14fc0881fa9f0"
+dependencies = [
+ "ct-codecs",
+ "ed25519-compact",
+ "getrandom 0.4.2",
+ "orion",
+ "p384",
+ "rand_core 0.6.4",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha2",
+ "subtle",
+ "time",
+ "zeroize",
+]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
@@ -926,7 +3236,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -952,16 +3262,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "pretty_assertions"
@@ -974,6 +3339,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.110",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -983,10 +3367,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.42"
+name = "prodash"
+version = "30.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "5a6efc566849d3d9d737c5cb06cc50e48950ebe3d3f9d70631490fff3a07b139"
+dependencies = [
+ "parking_lot",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -998,12 +3391,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1011,6 +3430,27 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core 0.6.4",
+]
 
 [[package]]
 name = "ratatui"
@@ -1035,7 +3475,7 @@ dependencies = [
  "anstyle",
  "bitflags 2.10.0",
  "compact_str",
- "hashbrown",
+ "hashbrown 0.16.1",
  "indoc",
  "itertools 0.14.0",
  "kasuari",
@@ -1086,7 +3526,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
 dependencies = [
  "bitflags 2.10.0",
- "hashbrown",
+ "hashbrown 0.16.1",
  "indoc",
  "instability",
  "itertools 0.14.0",
@@ -1103,6 +3543,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.10.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags 2.10.0",
 ]
@@ -1137,22 +3586,75 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
+name = "rsqlite-vfs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1c93dd1c9683b438c392c492109cb702b8090b2bfc8fed6f6e4eb4523f17af3"
+dependencies = [
+ "bitflags 2.10.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+ "sqlite-wasm-rs",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
-name = "rustix"
-version = "1.1.2"
+name = "rustc-stable-hash"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "781442f29170c5c93b7185ad559492601acdc71d5bb0706f5868094f45cfcd08"
+
+[[package]]
+name = "rustfix"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "864792a841a1d785ba91b8d2a75e1936b40bc517020c3c2958ac403b92e4f00a"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tracing",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1168,10 +3670,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -1191,6 +3748,28 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-untagged"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9faf48a4a2d2693be24c6289dbe26552776eb7737074e6722891fadbe6c5058"
+dependencies = [
+ "erased-serde",
+ "serde",
+ "serde_core",
+ "typeid",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float 2.10.1",
+ "serde",
 ]
 
 [[package]]
@@ -1214,16 +3793,56 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_json"
-version = "1.0.145"
+name = "serde_ignored"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "115dffd5f3853e06e746965a20dcbae6ee747ae30b543d91b0e089668bb07798"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
+name = "sha1-checked"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
+dependencies = [
+ "digest",
+ "sha1",
 ]
 
 [[package]]
@@ -1233,9 +3852,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "shell-escape"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
@@ -1268,16 +3914,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
+name = "sized-chunks"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
+dependencies = [
+ "bitmaps",
+ "typenum",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4206ed3a67690b9c29b77d728f6acc3ce78f16bf846d83c94f76400320181b"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -1313,6 +4023,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "supports-hyperlinks"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e396b6523b11ccb83120b115a0b7366de372751aa6edf19844dfb13a6af97e91"
+
+[[package]]
+name = "supports-unicode"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1332,6 +4060,50 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1373,10 +4145,10 @@ dependencies = [
  "libc",
  "log",
  "memmem",
- "nix",
+ "nix 0.29.0",
  "num-derive",
  "num-traits",
- "ordered-float",
+ "ordered-float 4.6.0",
  "pest",
  "pest_derive",
  "phf",
@@ -1438,18 +4210,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
+ "itoa",
  "libc",
  "num-conv",
  "num_threads",
  "powerfmt",
  "serde",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -1457,6 +4240,173 @@ name = "time-core"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+
+[[package]]
+name = "time-macros"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.24.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01f2eadbbc6b377a847be05f60791ef1058d9f696ecb51d2c07fe911d8569d8e"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.1",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
+]
+
+[[package]]
+name = "tracing-chrome"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf0a738ed5d6450a9fb96e86a23ad808de2b727fd1394585da5cdd6788ffe724"
+dependencies = [
+ "serde_json",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
@@ -1471,10 +4421,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
+name = "unicode-bom"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -1495,9 +4466,33 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1512,10 +4507,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
  "atomic",
- "getrandom",
+ "getrandom 0.3.4",
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -1533,6 +4540,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1544,7 +4561,16 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -1593,6 +4619,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.10.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "wezterm-bidi"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1608,7 +4668,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
  "mac_address",
  "sha2",
  "thiserror 1.0.69",
@@ -1634,7 +4694,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
 dependencies = [
  "log",
- "ordered-float",
+ "ordered-float 4.6.0",
  "strsim",
  "thiserror 1.0.69",
  "wezterm-dynamic-derive",
@@ -1681,6 +4741,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1694,6 +4763,24 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -1702,13 +4789,372 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+
+[[package]]
 name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.110",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.10.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,7 +402,6 @@ dependencies = [
  "cargo-util",
  "clap",
  "clap-cargo",
- "compact_str",
  "crossterm",
  "pretty_assertions",
  "ratatui",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,7 @@ dependencies = [
  "cargo_metadata",
  "clap",
  "clap-cargo",
+ "compact_str",
  "crossterm",
  "pretty_assertions",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ anyhow = "1.0.100"
 cargo_metadata = "0.23.1"
 clap = { version = "4.5.53", features = ["derive"] }
 clap-cargo = "0.18.3"
+compact_str = "0.9"
 crossterm = "0.29.0"
 ratatui = { version = "0.30.0", features = ["layout-cache"] }
 ratatui-core = { version = "0.1.0", features = ["anstyle"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ path = "src/bin/cargo/main.rs"
 
 [dependencies]
 anyhow = "1.0.100"
-cargo_metadata = "0.23.1"
+cargo = "=0.95.0"
+cargo-util = "0.2.27"
 clap = { version = "4.5.53", features = ["derive"] }
 clap-cargo = "0.18.3"
 compact_str = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ cargo = "=0.95.0"
 cargo-util = "0.2.27"
 clap = { version = "4.5.53", features = ["derive"] }
 clap-cargo = "0.18.3"
-compact_str = "0.9"
 crossterm = "0.29.0"
 ratatui = { version = "0.30.0", features = ["layout-cache"] }
 ratatui-core = { version = "0.1.0", features = ["anstyle"] }

--- a/src/bin/cargo/commands/tree_tui.rs
+++ b/src/bin/cargo/commands/tree_tui.rs
@@ -17,6 +17,7 @@ use crate::cli::TreeArgs;
 /// Entry point for the `cargo tree-tui` command.
 pub fn run(args: TreeArgs) -> Result<()> {
     let dependency_tree = DependencyTree::load(args.manifest_path)?;
+
     let (search_tx, search_rx) = mpsc::channel::<SearchRequest>();
     let (event_tx, event_rx) = mpsc::channel::<Event>();
     let worker_tree = dependency_tree.clone();

--- a/src/core/dependency.rs
+++ b/src/core/dependency.rs
@@ -1,16 +1,13 @@
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-use cargo_metadata::{DependencyKind, MetadataCommand, Node, Package, PackageId, TargetKind};
+use cargo_metadata::{
+    DependencyKind, Metadata, MetadataCommand, Node, Package, PackageId, TargetKind,
+};
 use clap_cargo::style::{DEP_BUILD, DEP_DEV, DEP_NORMAL};
+use compact_str::CompactString;
 use ratatui::style::Style;
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
-
-/// Key type for uniquely identifying nodes in the dependency tree.
-///
-/// This consists of the [`PackageId`] and an optional parent [`NodeId`] to
-/// differentiate multiple appearances of the same package in different tree locations.
-type NodeKey = (PackageId, Option<NodeId>);
+use rustc_hash::{FxHashMap, FxHashSet};
 
 /// Identifier for a node within the dependency tree arena.
 ///
@@ -27,7 +24,7 @@ pub enum DependencyType {
 }
 
 impl DependencyType {
-    fn label(&self) -> &'static str {
+    pub fn label(&self) -> &'static str {
         match self {
             Self::Normal => "[dependencies]",
             Self::Dev => "[dev-dependencies]",
@@ -56,41 +53,58 @@ impl TryFrom<DependencyKind> for DependencyType {
     }
 }
 
-/// Flat representation of a dependency node in the tree.
+/// Flat representation of a dependency node in the deduplicated tree.
 ///
 /// See [`DependencyTree`] for the full tree structure.
 #[derive(Debug, Clone)]
 pub struct Dependency {
     /// Crate name.
-    pub name: String,
+    pub name: CompactString,
     /// Crate version.
-    pub version: String,
+    pub version: CompactString,
     /// Local manifest directory (only for workspace members).
-    pub manifest_dir: Option<String>,
+    pub manifest_dir: Option<CompactString>,
     /// Whether this crate exposes a proc-macro target.
     pub is_proc_macro: bool,
-    /// Optional parent pointer for quick upward navigation.
-    pub parent: Option<NodeId>,
     /// Children represented as node indices for downward traversal.
     pub children: Vec<NodeId>,
 }
 
-/// Dependency group node (e.g. `[dev-dependencies]`) within the tree.
+impl From<&Package> for Dependency {
+    fn from(package: &Package) -> Self {
+        let manifest_dir = if package.source.is_none() {
+            package
+                .manifest_path
+                .parent()
+                .map(|parent| parent.as_str().into())
+        } else {
+            None
+        };
+
+        let is_proc_macro = package.targets.iter().any(|target| {
+            target
+                .kind
+                .iter()
+                .any(|kind| matches!(kind, TargetKind::ProcMacro))
+        });
+
+        Dependency {
+            name: package.name.as_str().into(),
+            version: package.version.to_string().into(),
+            manifest_dir,
+            is_proc_macro,
+            children: Vec::new(), // filled in by wire_edges
+        }
+    }
+}
+
+/// Dependency group node (e.g. `[dev-dependencies]`) within the deduplicated tree.
 #[derive(Debug, Clone)]
 pub struct DependencyGroup {
     /// Group kind in Cargo metadata.
     pub kind: DependencyType,
-    /// Optional parent pointer for quick upward navigation.
-    pub parent: Option<NodeId>,
     /// Children represented as node indices for downward traversal.
     pub children: Vec<NodeId>,
-}
-
-/// Unified dependency node type for the tree arena.
-#[derive(Debug, Clone)]
-pub enum DependencyNode {
-    Crate(Dependency),
-    Group(DependencyGroup),
 }
 
 impl DependencyGroup {
@@ -99,14 +113,14 @@ impl DependencyGroup {
     }
 }
 
-impl DependencyNode {
-    pub fn parent(&self) -> Option<NodeId> {
-        match self {
-            Self::Crate(node) => node.parent,
-            Self::Group(node) => node.parent,
-        }
-    }
+/// Unified dependency node type for the deduplicated tree arena.
+#[derive(Debug, Clone)]
+pub enum DependencyNode {
+    Crate(Dependency),
+    Group(DependencyGroup),
+}
 
+impl DependencyNode {
     pub fn children(&self) -> &[NodeId] {
         match self {
             Self::Crate(node) => &node.children,
@@ -138,29 +152,32 @@ impl DependencyNode {
             _ => None,
         }
     }
+
+    #[deprecated(note = "pre-refactor")]
+    pub fn parent(&self) -> Option<NodeId> {
+        None
+    }
 }
 
-/// Container for the resolved dependency tree scoped to the current workspace.
+/// Deduplicated dependency tree: one arena node per unique package.
 ///
-/// The tree is stored in an arena-like structure where each node references its children
-/// by their indices. This allows for efficient traversal and manipulation of the tree.
-///
-/// See also [`Dependency`].
+/// Parent relationships are stored in a separate reverse-index rather than
+/// on each node, since a deduplicated node can have multiple parents.
 #[derive(Debug, Clone)]
 pub struct DependencyTree {
     /// Name of the root package (or workspace placeholder when missing).
-    pub workspace_name: String,
+    pub workspace_name: CompactString,
     /// Arena storing all dependency nodes.
     pub nodes: Vec<DependencyNode>,
+    /// For each node, the list of parent node ids (reverse index of children).
+    pub parents: Vec<Vec<NodeId>>,
     /// Workspace members represented as node ids (entry points into the arena).
     pub roots: Vec<NodeId>,
-    /// Flat list of crate nodes for search.
-    pub crate_nodes: Vec<NodeId>,
 }
 
 impl DependencyTree {
     /// Loads Cargo metadata (optionally for a specific manifest) and converts it into a
-    /// [`DependencyTree`] with recursively resolved children.
+    /// [`DependencyTree`] with iteratively resolved children.
     pub fn load(manifest_path: Option<PathBuf>) -> Result<Self> {
         let mut cmd = MetadataCommand::new();
 
@@ -172,62 +189,16 @@ impl DependencyTree {
 
         let workspace_name = metadata
             .root_package()
-            .map(|pkg| pkg.name.to_string())
-            .unwrap_or_else(|| "workspace".to_string());
+            .map(|pkg| pkg.name.as_str().into())
+            .unwrap_or_else(|| "workspace".into());
 
-        let resolve = metadata
-            .resolve
-            .as_ref()
-            .context("failed to resolve dependency graph")?;
-
-        // Create maps for easy lookup.
-        let package_map: HashMap<&PackageId, &Package> =
-            metadata.packages.iter().map(|pkg| (&pkg.id, pkg)).collect();
-
-        // Map of [`PackageId`] to [`Node`] for quick access during tree construction.
-        let resolve_nodes: HashMap<&PackageId, &Node> =
-            resolve.nodes.iter().map(|node| (&node.id, node)).collect();
-
-        // Main tree construction (these types will be filled in during recursion).
-        let mut nodes = Vec::new();
-        let mut roots = Vec::new();
-        let mut node_map: HashMap<NodeKey, NodeId> = HashMap::default();
-
-        // For only including packages that belong to the current workspace
-        // to avoid third-party crates.
-        let workspace_package_ids: HashSet<PackageId> = metadata
-            .workspace_members
-            .iter()
-            .cloned()
-            .collect::<HashSet<_>>();
-
-        // Recursively build dependency nodes for each workspace member.
-        for package in metadata
-            .packages
-            .iter()
-            .filter(|pkg| workspace_package_ids.contains(&pkg.id))
-        {
-            if let Some(dependency) = Self::build_dependency_node(
-                &package.id,
-                None,
-                &resolve_nodes,
-                &package_map,
-                &mut node_map,
-                &mut nodes,
-            ) {
-                roots.push(dependency);
-            }
-        }
+        let deps = build_dependency_tree(&metadata)?;
 
         Ok(DependencyTree {
             workspace_name,
-            crate_nodes: nodes
-                .iter()
-                .enumerate()
-                .filter_map(|(idx, node)| (!node.is_group()).then_some(NodeId(idx)))
-                .collect(),
-            nodes,
-            roots,
+            parents: deps.parents,
+            nodes: deps.nodes,
+            roots: deps.roots,
         })
     }
 
@@ -242,134 +213,212 @@ impl DependencyTree {
     }
 
     /// Returns the crate node ids that can be matched by search.
-    pub fn crate_nodes(&self) -> &[NodeId] {
-        &self.crate_nodes
+    pub fn crate_nodes(&self) -> impl Iterator<Item = NodeId> {
+        self.nodes
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, node)| (!node.is_group()).then_some(NodeId(idx)))
     }
+}
 
-    /// Recursively constructs dependency nodes.
-    ///
-    /// # Notes
-    ///
-    /// - Each [`NodeKey`] is stored in `node_map` to avoid duplicating nodes.
-    /// - The `parent` parameter allows tracking the parent node during recursion.
-    fn build_dependency_node(
-        package_id: &PackageId,
-        parent: Option<NodeId>,
-        resolve_nodes: &HashMap<&PackageId, &cargo_metadata::Node>,
-        package_map: &HashMap<&PackageId, &cargo_metadata::Package>,
-        node_map: &mut HashMap<(PackageId, Option<NodeId>), NodeId>,
-        nodes: &mut Vec<DependencyNode>,
-    ) -> Option<NodeId> {
-        // Avoid duplicating nodes by checking the map first.
-        let key = (package_id.clone(), parent);
-        if let Some(&existing) = node_map.get(&key) {
-            return Some(existing);
+struct BuildResult {
+    roots: Vec<NodeId>,
+    nodes: Vec<DependencyNode>,
+    parents: Vec<Vec<NodeId>>,
+}
+
+fn build_dependency_tree(metadata: &Metadata) -> Result<BuildResult> {
+    let resolved = resolve_metadata(metadata)?;
+    let mut collected = collect_packages(&resolved);
+    let parents = wire_edges(&resolved, &collected.pkg_index, &mut collected.nodes);
+
+    Ok(BuildResult {
+        roots: collected.roots,
+        nodes: collected.nodes,
+        parents,
+    })
+}
+
+/// Resolved cargo metadata ready for tree construction.
+struct ResolvedMetadata<'a> {
+    packages: FxHashMap<&'a PackageId, &'a Package>,
+    resolve_nodes: FxHashMap<&'a PackageId, &'a Node>,
+    workspace_ids: Vec<PackageId>,
+}
+
+/// Validate the resolve graph and build lookup maps from cargo metadata.
+fn resolve_metadata(metadata: &Metadata) -> Result<ResolvedMetadata<'_>> {
+    let resolve = metadata
+        .resolve
+        .as_ref()
+        .context("failed to resolve dependency graph")?;
+
+    let packages = metadata.packages.iter().map(|pkg| (&pkg.id, pkg)).collect();
+
+    let resolve_nodes = resolve.nodes.iter().map(|node| (&node.id, node)).collect();
+
+    let workspace_members: FxHashSet<&PackageId> = metadata.workspace_members.iter().collect();
+    let workspace_ids = metadata
+        .packages
+        .iter()
+        .filter(|pkg| workspace_members.contains(&pkg.id))
+        .map(|pkg| pkg.id.clone())
+        .collect();
+
+    Ok(ResolvedMetadata {
+        packages,
+        resolve_nodes,
+        workspace_ids,
+    })
+}
+
+/// The node arena with empty children, a package-to-node index, and root ids.
+struct CollectedPackages {
+    nodes: Vec<DependencyNode>,
+    pkg_index: FxHashMap<PackageId, NodeId>,
+    roots: Vec<NodeId>,
+}
+
+/// Create one `DependencyNode::Crate` per reachable package.
+///
+/// DFS from workspace roots. Nodes have empty children at this point.
+fn collect_packages(resolved: &ResolvedMetadata<'_>) -> CollectedPackages {
+    let capacity = resolved.packages.len();
+    let mut remaining: Vec<&PackageId> = Vec::with_capacity(capacity);
+    remaining.extend(resolved.workspace_ids.iter());
+
+    let mut nodes: Vec<DependencyNode> = Vec::with_capacity(capacity);
+    let mut pkg_index: FxHashMap<PackageId, NodeId> =
+        FxHashMap::with_capacity_and_hasher(capacity, Default::default());
+
+    while let Some(package_id) = remaining.pop() {
+        if pkg_index.contains_key(package_id) {
+            continue;
         }
 
-        // Retrieve package information.
-        let package = *package_map.get(package_id)?;
-        let manifest_dir = if package.source.is_none() {
-            package
-                .manifest_path
-                .parent()
-                .map(|parent| parent.to_string())
-        } else {
-            None
-        };
-        let is_proc_macro = package.targets.iter().any(|target| {
-            target
-                .kind
-                .iter()
-                .any(|kind| matches!(kind, TargetKind::ProcMacro))
-        });
+        let package = resolved.packages[package_id];
 
-        // Create the new dependency node.
         let node_id = NodeId(nodes.len());
-        nodes.push(DependencyNode::Crate(Dependency {
-            name: package.name.to_string(),
-            version: package.version.to_string(),
-            manifest_dir,
-            is_proc_macro,
-            parent,
-            children: Vec::new(),
-        }));
-        node_map.insert(key, node_id);
+        nodes.push(DependencyNode::Crate(Dependency::from(package)));
+        pkg_index.insert(package_id.clone(), node_id);
 
-        // Recursively build child nodes.
-        let Some(node) = resolve_nodes.get(package_id) else {
-            return Some(node_id);
+        if let Some(node) = resolved.resolve_nodes.get(package_id) {
+            remaining.extend(node.deps.iter().map(|dep| &dep.pkg));
+        }
+    }
+
+    let roots = resolved
+        .workspace_ids
+        .iter()
+        .filter_map(|pkg_id| pkg_index.get(pkg_id).copied())
+        .collect();
+
+    CollectedPackages {
+        nodes,
+        pkg_index,
+        roots,
+    }
+}
+
+/// Classify each crate's deps by kind.
+///
+/// Attaches normal deps as direct children, creates group nodes for dev/build
+/// deps, and builds the parents reverse-index.
+fn wire_edges(
+    resolved: &ResolvedMetadata<'_>,
+    pkg_index: &FxHashMap<PackageId, NodeId>,
+    nodes: &mut Vec<DependencyNode>,
+) -> Vec<Vec<NodeId>> {
+    let mut parents: Vec<Vec<NodeId>> = vec![Vec::new(); nodes.len()];
+
+    for (pkg_id, &node_id) in pkg_index.iter() {
+        let Some(resolved_node) = resolved.resolve_nodes.get(pkg_id) else {
+            continue;
         };
 
-        let mut normal = Vec::new();
-        let mut dev = Vec::new();
-        let mut build = Vec::new();
+        let mut classified = ClassifiedDeps::populate(resolved_node, pkg_index);
 
-        for dep in &node.deps {
+        let mut children: Vec<NodeId> = Vec::with_capacity(
+            classified.normal.len()
+                + classified.has_dev() as usize  // expanded as group, so one child
+                + classified.has_build() as usize,
+        );
+
+        // Normal deps are direct children of the crate node.
+        for &child_id in &classified.normal {
+            children.push(child_id);
+            parents[child_id.0].push(node_id);
+        }
+
+        // Dev and build deps go under group nodes.
+        for (kind, group_deps) in [
+            (DependencyType::Dev, &mut classified.dev),
+            (DependencyType::Build, &mut classified.build),
+        ] {
+            if group_deps.is_empty() {
+                continue;
+            }
+
+            let group_id = NodeId(nodes.len());
+            for &child_id in group_deps.iter() {
+                parents[child_id.0].push(group_id);
+            }
+
+            nodes.push(DependencyNode::Group(DependencyGroup {
+                kind,
+                children: std::mem::take(group_deps),
+            }));
+
+            parents.push(vec![node_id]);
+            children.push(group_id);
+        }
+
+        if let Some(DependencyNode::Crate(dep)) = nodes.get_mut(node_id.0) {
+            dep.children = children;
+        }
+    }
+
+    parents
+}
+
+#[derive(Default)]
+struct ClassifiedDeps {
+    normal: Vec<NodeId>,
+    dev: Vec<NodeId>,
+    build: Vec<NodeId>,
+}
+
+impl ClassifiedDeps {
+    /// Classify a resolved node's dependencies into normal, dev, and build buckets.
+    fn populate(resolved_node: &Node, pkg_index: &FxHashMap<PackageId, NodeId>) -> Self {
+        let mut classified = ClassifiedDeps::default();
+
+        for dep in &resolved_node.deps {
             let dep_type = dep
                 .dep_kinds
                 .iter()
                 .find_map(|kind| DependencyType::try_from(kind.kind).ok());
+
+            let Some(&child_id) = pkg_index.get(&dep.pkg) else {
+                continue;
+            };
+
             match dep_type {
-                Some(DependencyType::Normal) => normal.push(&dep.pkg),
-                Some(DependencyType::Dev) => dev.push(&dep.pkg),
-                Some(DependencyType::Build) => build.push(&dep.pkg),
+                Some(DependencyType::Normal) => classified.normal.push(child_id),
+                Some(DependencyType::Dev) => classified.dev.push(child_id),
+                Some(DependencyType::Build) => classified.build.push(child_id),
                 None => {}
             }
         }
 
-        let mut children = Vec::new();
-        for dep_id in normal {
-            if let Some(child) = Self::build_dependency_node(
-                dep_id,
-                Some(node_id),
-                resolve_nodes,
-                package_map,
-                node_map,
-                nodes,
-            ) {
-                children.push(child);
-            }
-        }
+        classified
+    }
 
-        let mut build_group = |kind: DependencyType, deps: Vec<&PackageId>| {
-            if deps.is_empty() {
-                return;
-            }
+    fn has_dev(&self) -> bool {
+        !self.dev.is_empty()
+    }
 
-            let group_id = NodeId(nodes.len());
-            nodes.push(DependencyNode::Group(DependencyGroup {
-                kind,
-                parent: Some(node_id),
-                children: Vec::new(),
-            }));
-            children.push(group_id);
-
-            let children = deps
-                .into_iter()
-                .filter_map(|dep_id| {
-                    Self::build_dependency_node(
-                        dep_id,
-                        Some(group_id),
-                        resolve_nodes,
-                        package_map,
-                        node_map,
-                        nodes,
-                    )
-                })
-                .collect();
-
-            if let Some(DependencyNode::Group(group)) = nodes.get_mut(group_id.0) {
-                group.children = children;
-            }
-        };
-
-        build_group(DependencyType::Dev, dev);
-        build_group(DependencyType::Build, build);
-
-        if let Some(DependencyNode::Crate(dependency)) = nodes.get_mut(node_id.0) {
-            dependency.children = children;
-        }
-
-        Some(node_id)
+    fn has_build(&self) -> bool {
+        !self.build.is_empty()
     }
 }

--- a/src/core/dependency.rs
+++ b/src/core/dependency.rs
@@ -14,7 +14,6 @@ use cargo::{
 };
 use cargo_util::paths::normalize_path;
 use clap_cargo::style::{DEP_BUILD, DEP_DEV, DEP_NORMAL};
-use compact_str::CompactString;
 use ratatui::style::Style;
 use rustc_hash::FxHashMap;
 
@@ -66,11 +65,11 @@ impl From<DepKind> for DependencyType {
 #[derive(Debug, Clone)]
 pub struct Dependency {
     /// Crate name.
-    pub name: CompactString,
+    pub name: String,
     /// Crate version.
-    pub version: CompactString,
+    pub version: String,
     /// Local manifest directory (only for workspace members).
-    pub manifest_dir: Option<CompactString>,
+    pub manifest_dir: Option<String>,
     /// Whether this crate exposes a proc-macro target.
     pub is_proc_macro: bool,
     /// Children represented as node indices for downward traversal.
@@ -149,10 +148,30 @@ impl DependencyNode {
 ///
 /// Parent relationships are stored in a separate reverse-index rather than
 /// on each node, since a deduplicated node can have multiple parents.
+///
+/// Example:
+///
+/// app
+/// |- foo
+/// |  `- baz
+/// `- bar
+///    `- baz
+///
+/// nodes:
+///   0 = app(children = [1, 2])
+///   1 = foo(children = [3])
+///   2 = bar(children = [3])
+///   3 = baz(children = [])
+///
+/// parents:
+///   0 -> []
+///   1 -> [0]
+///   2 -> [0]
+///   3 -> [1, 2]
 #[derive(Debug, Clone)]
 pub struct DependencyTree {
     /// Name of the root package (or workspace placeholder when missing).
-    pub workspace_name: CompactString,
+    pub workspace_name: String,
     /// Arena storing all dependency nodes.
     pub nodes: Vec<DependencyNode>,
     /// For each node, the list of parent node ids (reverse index of children).
@@ -167,13 +186,14 @@ impl DependencyTree {
     pub fn load(manifest_path: Option<PathBuf>) -> Result<Self> {
         let resolved = ResolvedWorkspace::load(manifest_path)?;
         let workspace_name = resolved.workspace_name.clone();
-        let deps = build_dependency_tree(&resolved);
+        let mut collected = collect_packages(&resolved);
+        let parents = wire_edges(&resolved, &collected.pkg_index, &mut collected.nodes);
 
         Ok(DependencyTree {
             workspace_name,
-            parents: deps.parents,
-            nodes: deps.nodes,
-            roots: deps.roots,
+            parents,
+            nodes: collected.nodes,
+            roots: collected.roots,
         })
     }
 
@@ -198,9 +218,9 @@ impl DependencyTree {
 
 /// Snapshot of a Cargo package with the fields required fields.
 pub struct PackageSnapshot {
-    name: CompactString,
-    version: CompactString,
-    manifest_dir: Option<CompactString>,
+    name: String,
+    version: String,
+    manifest_dir: Option<String>,
     is_proc_macro: bool,
 }
 
@@ -210,11 +230,11 @@ impl PackageSnapshot {
             .package_id()
             .source_id()
             .is_path()
-            .then(|| package.root().display().to_string().into());
+            .then(|| package.root().display().to_string());
 
         Self {
-            name: package.name().as_str().into(),
-            version: package.version().to_string().into(),
+            name: package.name().as_str().to_owned(),
+            version: package.version().to_string(),
             manifest_dir,
             is_proc_macro: package.proc_macro(),
         }
@@ -223,7 +243,7 @@ impl PackageSnapshot {
 
 /// Resolved Cargo workspace with the data required to build the dependency tree.
 struct ResolvedWorkspace {
-    workspace_name: CompactString,
+    workspace_name: String,
     packages: FxHashMap<PackageId, PackageSnapshot>,
     /// Deduplicated, classified outgoing edges keyed by source package.
     edges: FxHashMap<PackageId, Vec<(PackageId, DependencyType)>>,
@@ -231,6 +251,13 @@ struct ResolvedWorkspace {
 }
 
 impl ResolvedWorkspace {
+    /// Resolve a Cargo workspace into the minimal data needed to build the
+    /// deduplicated dependency tree.
+    ///
+    /// This loads the workspace through Cargo's own resolver, snapshots each
+    /// reachable package into a compact [`PackageSnapshot`], classifies outgoing
+    /// edges by dependency kind, and records the workspace member ids that act
+    /// as graph roots.
     fn load(manifest_path: Option<PathBuf>) -> Result<Self> {
         let gctx = GlobalContext::default().context("failed to initialize Cargo context")?;
         let manifest_path = resolve_manifest_path(&gctx, manifest_path)?;
@@ -242,6 +269,7 @@ impl ResolvedWorkspace {
             CompileKindFallback::JustHost,
         )
         .context("failed to determine Cargo target kinds")?;
+
         let mut target_data =
             RustcTargetData::new(&ws, &requested_kinds).context("failed to load target data")?;
         let specs = ops::Packages::All(Vec::new())
@@ -264,8 +292,8 @@ impl ResolvedWorkspace {
 
         let workspace_name = ws
             .current_opt()
-            .map(|pkg| pkg.name().as_str().into())
-            .unwrap_or_else(|| "workspace".into());
+            .map(|pkg| pkg.name().as_str().to_owned())
+            .unwrap_or_else(|| "workspace".to_owned());
 
         // Snapshot every reachable package: workspace members first (so a
         // member that also appears in pkg_set keeps its workspace identity),
@@ -315,6 +343,8 @@ impl ResolvedWorkspace {
     }
 }
 
+/// Helper function to resolve the manifest path, handling absolute vs relative paths and
+/// defaulting to finding the workspace root when no path is provided.
 fn resolve_manifest_path(gctx: &GlobalContext, manifest_path: Option<PathBuf>) -> Result<PathBuf> {
     let raw = match manifest_path {
         Some(path) if path.is_absolute() => path,
@@ -328,23 +358,6 @@ fn resolve_manifest_path(gctx: &GlobalContext, manifest_path: Option<PathBuf>) -
     Ok(normalize_path(&raw))
 }
 
-struct BuildResult {
-    roots: Vec<NodeId>,
-    nodes: Vec<DependencyNode>,
-    parents: Vec<Vec<NodeId>>,
-}
-
-fn build_dependency_tree(resolved: &ResolvedWorkspace) -> BuildResult {
-    let mut collected = collect_packages(resolved);
-    let parents = wire_edges(resolved, &collected.pkg_index, &mut collected.nodes);
-
-    BuildResult {
-        roots: collected.roots,
-        nodes: collected.nodes,
-        parents,
-    }
-}
-
 /// The node arena with empty children, a package-to-node index, and root ids.
 struct CollectedPackages {
     nodes: Vec<DependencyNode>,
@@ -352,9 +365,10 @@ struct CollectedPackages {
     roots: Vec<NodeId>,
 }
 
-/// Create one `DependencyNode::Crate` per reachable package.
+/// Create one [`DependencyNode::Crate`] per reachable package.
 ///
-/// DFS from workspace roots. Nodes have empty children at this point.
+/// Starting from the workspace roots, walk the resolved graph and assign each
+/// unique package a stable arena node id. Child links are filled in later.
 fn collect_packages(resolved: &ResolvedWorkspace) -> CollectedPackages {
     let capacity = resolved.packages.len();
     let mut remaining: Vec<PackageId> = Vec::with_capacity(capacity);
@@ -395,10 +409,15 @@ fn collect_packages(resolved: &ResolvedWorkspace) -> CollectedPackages {
     }
 }
 
-/// Classify each crate's deps by kind.
+/// Wire the dependency edges between the already-collected arena nodes.
 ///
-/// Attaches normal deps as direct children, creates group nodes for dev/build
-/// deps, and builds the parents reverse-index.
+/// Normal dependencies become direct children of the crate node.
+///
+/// Dev and build dependencies are grouped under synthetic
+/// `[dev-dependencies]` / `[build-dependencies]` nodes.
+///
+/// While attaching those child links, this pass also builds the reverse
+/// parent index for every node.
 fn wire_edges(
     resolved: &ResolvedWorkspace,
     pkg_index: &FxHashMap<PackageId, NodeId>,

--- a/src/core/dependency.rs
+++ b/src/core/dependency.rs
@@ -152,11 +152,6 @@ impl DependencyNode {
             _ => None,
         }
     }
-
-    #[deprecated(note = "pre-refactor")]
-    pub fn parent(&self) -> Option<NodeId> {
-        None
-    }
 }
 
 /// Deduplicated dependency tree: one arena node per unique package.

--- a/src/core/dependency.rs
+++ b/src/core/dependency.rs
@@ -1,13 +1,22 @@
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-use cargo_metadata::{
-    DependencyKind, Metadata, MetadataCommand, Node, Package, PackageId, TargetKind,
+use cargo::{
+    GlobalContext,
+    core::{
+        Package, PackageId, Workspace,
+        compiler::{CompileKind, CompileKindFallback, RustcTargetData},
+        dependency::DepKind,
+        resolver::features::{CliFeatures, ForceAllTargets, HasDevUnits},
+    },
+    ops,
+    util::important_paths::find_root_manifest_for_wd,
 };
+use cargo_util::paths::normalize_path;
 use clap_cargo::style::{DEP_BUILD, DEP_DEV, DEP_NORMAL};
 use compact_str::CompactString;
 use ratatui::style::Style;
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 
 /// Identifier for a node within the dependency tree arena.
 ///
@@ -41,14 +50,12 @@ impl DependencyType {
     }
 }
 
-impl TryFrom<DependencyKind> for DependencyType {
-    type Error = ();
-    fn try_from(value: DependencyKind) -> Result<Self, Self::Error> {
+impl From<DepKind> for DependencyType {
+    fn from(value: DepKind) -> Self {
         match value {
-            DependencyKind::Normal => Ok(Self::Normal),
-            DependencyKind::Development => Ok(Self::Dev),
-            DependencyKind::Build => Ok(Self::Build),
-            _ => Err(()),
+            DepKind::Normal => Self::Normal,
+            DepKind::Development => Self::Dev,
+            DepKind::Build => Self::Build,
         }
     }
 }
@@ -70,29 +77,13 @@ pub struct Dependency {
     pub children: Vec<NodeId>,
 }
 
-impl From<&Package> for Dependency {
-    fn from(package: &Package) -> Self {
-        let manifest_dir = if package.source.is_none() {
-            package
-                .manifest_path
-                .parent()
-                .map(|parent| parent.as_str().into())
-        } else {
-            None
-        };
-
-        let is_proc_macro = package.targets.iter().any(|target| {
-            target
-                .kind
-                .iter()
-                .any(|kind| matches!(kind, TargetKind::ProcMacro))
-        });
-
+impl From<&PackageSnapshot> for Dependency {
+    fn from(snapshot: &PackageSnapshot) -> Self {
         Dependency {
-            name: package.name.as_str().into(),
-            version: package.version.to_string().into(),
-            manifest_dir,
-            is_proc_macro,
+            name: snapshot.name.clone(),
+            version: snapshot.version.clone(),
+            manifest_dir: snapshot.manifest_dir.clone(),
+            is_proc_macro: snapshot.is_proc_macro,
             children: Vec::new(), // filled in by wire_edges
         }
     }
@@ -171,23 +162,12 @@ pub struct DependencyTree {
 }
 
 impl DependencyTree {
-    /// Loads Cargo metadata (optionally for a specific manifest) and converts it into a
-    /// [`DependencyTree`] with iteratively resolved children.
+    /// Resolves the Cargo workspace via the `cargo` library and converts the
+    /// resolved graph into a [`DependencyTree`].
     pub fn load(manifest_path: Option<PathBuf>) -> Result<Self> {
-        let mut cmd = MetadataCommand::new();
-
-        if let Some(path) = manifest_path {
-            cmd.manifest_path(path);
-        }
-
-        let metadata = cmd.exec().context("failed to execute Cargo metadata")?;
-
-        let workspace_name = metadata
-            .root_package()
-            .map(|pkg| pkg.name.as_str().into())
-            .unwrap_or_else(|| "workspace".into());
-
-        let deps = build_dependency_tree(&metadata)?;
+        let resolved = ResolvedWorkspace::load(manifest_path)?;
+        let workspace_name = resolved.workspace_name.clone();
+        let deps = build_dependency_tree(&resolved);
 
         Ok(DependencyTree {
             workspace_name,
@@ -216,55 +196,153 @@ impl DependencyTree {
     }
 }
 
+/// Snapshot of a Cargo package with the fields required fields.
+pub struct PackageSnapshot {
+    name: CompactString,
+    version: CompactString,
+    manifest_dir: Option<CompactString>,
+    is_proc_macro: bool,
+}
+
+impl PackageSnapshot {
+    fn from_package(package: &Package) -> Self {
+        let manifest_dir = package
+            .package_id()
+            .source_id()
+            .is_path()
+            .then(|| package.root().display().to_string().into());
+
+        Self {
+            name: package.name().as_str().into(),
+            version: package.version().to_string().into(),
+            manifest_dir,
+            is_proc_macro: package.proc_macro(),
+        }
+    }
+}
+
+/// Resolved Cargo workspace with the data required to build the dependency tree.
+struct ResolvedWorkspace {
+    workspace_name: CompactString,
+    packages: FxHashMap<PackageId, PackageSnapshot>,
+    /// Deduplicated, classified outgoing edges keyed by source package.
+    edges: FxHashMap<PackageId, Vec<(PackageId, DependencyType)>>,
+    workspace_ids: Vec<PackageId>,
+}
+
+impl ResolvedWorkspace {
+    fn load(manifest_path: Option<PathBuf>) -> Result<Self> {
+        let gctx = GlobalContext::default().context("failed to initialize Cargo context")?;
+        let manifest_path = resolve_manifest_path(&gctx, manifest_path)?;
+        let ws = Workspace::new(&manifest_path, &gctx).context("failed to load Cargo workspace")?;
+
+        let requested_kinds = CompileKind::from_requested_targets_with_fallback(
+            ws.gctx(),
+            &[],
+            CompileKindFallback::JustHost,
+        )
+        .context("failed to determine Cargo target kinds")?;
+        let mut target_data =
+            RustcTargetData::new(&ws, &requested_kinds).context("failed to load target data")?;
+        let specs = ops::Packages::All(Vec::new())
+            .to_package_id_specs(&ws)
+            .context("failed to resolve workspace package specs")?;
+        let ws_resolve = ops::resolve_ws_with_opts(
+            &ws,
+            &mut target_data,
+            &requested_kinds,
+            &CliFeatures::new_all(true),
+            &specs,
+            HasDevUnits::Yes,
+            ForceAllTargets::Yes,
+            false,
+        )
+        .context("failed to resolve Cargo dependencies")?;
+
+        let pkg_set = ws_resolve.pkg_set;
+        let resolve = ws_resolve.targeted_resolve;
+
+        let workspace_name = ws
+            .current_opt()
+            .map(|pkg| pkg.name().as_str().into())
+            .unwrap_or_else(|| "workspace".into());
+
+        // Snapshot every reachable package: workspace members first (so a
+        // member that also appears in pkg_set keeps its workspace identity),
+        // then everything else from the resolved package set.
+        let mut packages: FxHashMap<PackageId, PackageSnapshot> = FxHashMap::default();
+        for pkg in ws.members() {
+            packages.insert(pkg.package_id(), PackageSnapshot::from_package(pkg));
+        }
+        for pkg in pkg_set.packages() {
+            packages
+                .entry(pkg.package_id())
+                .or_insert_with(|| PackageSnapshot::from_package(pkg));
+        }
+
+        // Build classified, kind-deduplicated edges keyed by source package.
+        let mut edges: FxHashMap<PackageId, Vec<(PackageId, DependencyType)>> =
+            FxHashMap::default();
+        for &pkg_id in packages.keys() {
+            let mut classified: Vec<(PackageId, DependencyType)> = Vec::new();
+            for (dep_id, deps) in resolve.deps(pkg_id) {
+                let mut seen_normal = false;
+                let mut seen_dev = false;
+                let mut seen_build = false;
+                for dep in deps.iter() {
+                    let kind = DependencyType::from(dep.kind());
+                    let already = match kind {
+                        DependencyType::Normal => std::mem::replace(&mut seen_normal, true),
+                        DependencyType::Dev => std::mem::replace(&mut seen_dev, true),
+                        DependencyType::Build => std::mem::replace(&mut seen_build, true),
+                    };
+                    if !already {
+                        classified.push((dep_id, kind));
+                    }
+                }
+            }
+            edges.insert(pkg_id, classified);
+        }
+
+        let workspace_ids = ws.members().map(|pkg| pkg.package_id()).collect();
+
+        Ok(ResolvedWorkspace {
+            workspace_name,
+            packages,
+            edges,
+            workspace_ids,
+        })
+    }
+}
+
+fn resolve_manifest_path(gctx: &GlobalContext, manifest_path: Option<PathBuf>) -> Result<PathBuf> {
+    let raw = match manifest_path {
+        Some(path) if path.is_absolute() => path,
+        Some(path) => gctx.cwd().join(path),
+        None => find_root_manifest_for_wd(gctx.cwd()).context("failed to find Cargo.toml")?,
+    };
+    // Cargo's `Workspace::new` compares manifest paths against the normalized
+    // paths it discovers via filesystem walks. Without lexical normalization,
+    // an input like `../zed/Cargo.toml` produces `.../cwd/../zed/Cargo.toml`
+    // and trips `validate_members` with a "wrong workspace" error.
+    Ok(normalize_path(&raw))
+}
+
 struct BuildResult {
     roots: Vec<NodeId>,
     nodes: Vec<DependencyNode>,
     parents: Vec<Vec<NodeId>>,
 }
 
-fn build_dependency_tree(metadata: &Metadata) -> Result<BuildResult> {
-    let resolved = resolve_metadata(metadata)?;
-    let mut collected = collect_packages(&resolved);
-    let parents = wire_edges(&resolved, &collected.pkg_index, &mut collected.nodes);
+fn build_dependency_tree(resolved: &ResolvedWorkspace) -> BuildResult {
+    let mut collected = collect_packages(resolved);
+    let parents = wire_edges(resolved, &collected.pkg_index, &mut collected.nodes);
 
-    Ok(BuildResult {
+    BuildResult {
         roots: collected.roots,
         nodes: collected.nodes,
         parents,
-    })
-}
-
-/// Resolved cargo metadata ready for tree construction.
-struct ResolvedMetadata<'a> {
-    packages: FxHashMap<&'a PackageId, &'a Package>,
-    resolve_nodes: FxHashMap<&'a PackageId, &'a Node>,
-    workspace_ids: Vec<PackageId>,
-}
-
-/// Validate the resolve graph and build lookup maps from cargo metadata.
-fn resolve_metadata(metadata: &Metadata) -> Result<ResolvedMetadata<'_>> {
-    let resolve = metadata
-        .resolve
-        .as_ref()
-        .context("failed to resolve dependency graph")?;
-
-    let packages = metadata.packages.iter().map(|pkg| (&pkg.id, pkg)).collect();
-
-    let resolve_nodes = resolve.nodes.iter().map(|node| (&node.id, node)).collect();
-
-    let workspace_members: FxHashSet<&PackageId> = metadata.workspace_members.iter().collect();
-    let workspace_ids = metadata
-        .packages
-        .iter()
-        .filter(|pkg| workspace_members.contains(&pkg.id))
-        .map(|pkg| pkg.id.clone())
-        .collect();
-
-    Ok(ResolvedMetadata {
-        packages,
-        resolve_nodes,
-        workspace_ids,
-    })
+    }
 }
 
 /// The node arena with empty children, a package-to-node index, and root ids.
@@ -277,28 +355,30 @@ struct CollectedPackages {
 /// Create one `DependencyNode::Crate` per reachable package.
 ///
 /// DFS from workspace roots. Nodes have empty children at this point.
-fn collect_packages(resolved: &ResolvedMetadata<'_>) -> CollectedPackages {
+fn collect_packages(resolved: &ResolvedWorkspace) -> CollectedPackages {
     let capacity = resolved.packages.len();
-    let mut remaining: Vec<&PackageId> = Vec::with_capacity(capacity);
-    remaining.extend(resolved.workspace_ids.iter());
+    let mut remaining: Vec<PackageId> = Vec::with_capacity(capacity);
+    remaining.extend(resolved.workspace_ids.iter().copied());
 
     let mut nodes: Vec<DependencyNode> = Vec::with_capacity(capacity);
     let mut pkg_index: FxHashMap<PackageId, NodeId> =
         FxHashMap::with_capacity_and_hasher(capacity, Default::default());
 
     while let Some(package_id) = remaining.pop() {
-        if pkg_index.contains_key(package_id) {
+        if pkg_index.contains_key(&package_id) {
             continue;
         }
 
-        let package = resolved.packages[package_id];
+        let Some(snapshot) = resolved.packages.get(&package_id) else {
+            continue;
+        };
 
         let node_id = NodeId(nodes.len());
-        nodes.push(DependencyNode::Crate(Dependency::from(package)));
-        pkg_index.insert(package_id.clone(), node_id);
+        nodes.push(DependencyNode::Crate(Dependency::from(snapshot)));
+        pkg_index.insert(package_id, node_id);
 
-        if let Some(node) = resolved.resolve_nodes.get(package_id) {
-            remaining.extend(node.deps.iter().map(|dep| &dep.pkg));
+        if let Some(deps) = resolved.edges.get(&package_id) {
+            remaining.extend(deps.iter().map(|(dep_id, _)| *dep_id));
         }
     }
 
@@ -320,19 +400,18 @@ fn collect_packages(resolved: &ResolvedMetadata<'_>) -> CollectedPackages {
 /// Attaches normal deps as direct children, creates group nodes for dev/build
 /// deps, and builds the parents reverse-index.
 fn wire_edges(
-    resolved: &ResolvedMetadata<'_>,
+    resolved: &ResolvedWorkspace,
     pkg_index: &FxHashMap<PackageId, NodeId>,
     nodes: &mut Vec<DependencyNode>,
 ) -> Vec<Vec<NodeId>> {
     let mut parents: Vec<Vec<NodeId>> = vec![Vec::new(); nodes.len()];
 
     for (pkg_id, &node_id) in pkg_index.iter() {
-        let Some(resolved_node) = resolved.resolve_nodes.get(pkg_id) else {
+        let Some(edges) = resolved.edges.get(pkg_id) else {
             continue;
         };
 
-        let mut classified = ClassifiedDeps::populate(resolved_node, pkg_index);
-
+        let mut classified = ClassifiedDeps::populate(edges, pkg_index);
         let mut children: Vec<NodeId> = Vec::with_capacity(
             classified.normal.len()
                 + classified.has_dev() as usize  // expanded as group, so one child
@@ -384,25 +463,22 @@ struct ClassifiedDeps {
 }
 
 impl ClassifiedDeps {
-    /// Classify a resolved node's dependencies into normal, dev, and build buckets.
-    fn populate(resolved_node: &Node, pkg_index: &FxHashMap<PackageId, NodeId>) -> Self {
+    /// Classify a package's edges into normal, dev, and build buckets.
+    fn populate(
+        edges: &[(PackageId, DependencyType)],
+        pkg_index: &FxHashMap<PackageId, NodeId>,
+    ) -> Self {
         let mut classified = ClassifiedDeps::default();
 
-        for dep in &resolved_node.deps {
-            let dep_type = dep
-                .dep_kinds
-                .iter()
-                .find_map(|kind| DependencyType::try_from(kind.kind).ok());
-
-            let Some(&child_id) = pkg_index.get(&dep.pkg) else {
+        for &(dep_id, kind) in edges {
+            let Some(&child_id) = pkg_index.get(&dep_id) else {
                 continue;
             };
 
-            match dep_type {
-                Some(DependencyType::Normal) => classified.normal.push(child_id),
-                Some(DependencyType::Dev) => classified.dev.push(child_id),
-                Some(DependencyType::Build) => classified.build.push(child_id),
-                None => {}
+            match kind {
+                DependencyType::Normal => classified.normal.push(child_id),
+                DependencyType::Dev => classified.dev.push(child_id),
+                DependencyType::Build => classified.build.push(child_id),
             }
         }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,2 +1,3 @@
 pub mod dependency;
+
 pub use dependency::{Dependency, DependencyGroup, DependencyNode, DependencyTree, NodeId};

--- a/src/ops/tree/tui/widget/breadcrumb.rs
+++ b/src/ops/tree/tui/widget/breadcrumb.rs
@@ -40,20 +40,25 @@ impl<'a> Breadcrumb<'a> {
     /// Collect the breadcrumb trail from root to the selected node.
     fn collect_crumbs(&self) -> Vec<Crumb> {
         let mut crumbs = Vec::new();
-        let mut current = self.state.selected;
+        // Walk the visible cache via parent_vis_idx for correct position-aware breadcrumbs.
+        let visible = self.state.active_visible_nodes();
+        let mut current_vis = self.state.selected_position_cached();
 
-        while let Some(id) = current {
-            if let Some(node) = self.tree.node(id) {
-                let group_style = node.as_group().map(|group| group.kind.style());
-                crumbs.push(Crumb {
-                    name: node.display_name().to_string(),
-                    group_style,
-                    is_group: node.is_group(),
-                });
-                current = node.parent();
-            } else {
+        while let Some(vis_idx) = current_vis {
+            let Some(vnode) = visible.get(vis_idx.0) else {
                 break;
-            }
+            };
+            let Some(node) = self.tree.node(vnode.id) else {
+                break;
+            };
+
+            let group_style = node.as_group().map(|group| group.kind.style());
+            crumbs.push(Crumb {
+                name: node.display_name().to_string(),
+                group_style,
+                is_group: node.is_group(),
+            });
+            current_vis = vnode.parent_vis_idx;
         }
 
         crumbs.reverse();

--- a/src/ops/tree/tui/widget/lineage.rs
+++ b/src/ops/tree/tui/widget/lineage.rs
@@ -1,5 +1,7 @@
-use crate::core::{DependencyTree, NodeId};
+use crate::core::DependencyTree;
 use ratatui::style::Style;
+
+use super::state::{VisIdx, VisibleNode};
 
 /// Lineage information for a dependency node.
 #[derive(Debug)]
@@ -20,35 +22,40 @@ pub struct LineageSegment {
 }
 
 impl Lineage {
-    /// Builds lineage information for a node.
+    /// Builds lineage information for a visible node position.
     pub fn build(
         tree: &DependencyTree,
-        node_id: NodeId,
-        selected: Option<NodeId>,
-        last_visible_non_group_child: Option<&[Option<NodeId>]>,
+        visible_nodes: &[VisibleNode],
+        vis_idx: VisIdx,
+        selected_vis_idx: Option<VisIdx>,
+        last_visible_non_group_child: Option<&[Option<VisIdx>]>,
     ) -> Option<Self> {
-        let node = tree.node(node_id)?;
+        let vnode = visible_nodes.get(vis_idx.0)?;
+        tree.node(vnode.id)?;
 
-        let is_last = match node.parent() {
-            Some(parent_id) => {
-                !Self::has_more_visible_siblings(node_id, parent_id, last_visible_non_group_child)
+        let is_last = match vnode.parent_vis_idx {
+            Some(parent_vis) => {
+                !Self::has_more_visible_siblings(vis_idx, parent_vis, last_visible_non_group_child)
             }
             None => true,
         };
 
         let mut lineage = Vec::new();
-        let mut current = node.parent();
+        let mut current_vis = vnode.parent_vis_idx;
 
-        while let Some(ancestor_id) = current {
-            let ancestor = tree.node(ancestor_id)?;
-            if let Some(grand_id) = ancestor.parent() {
+        while let Some(ancestor_vis) = current_vis {
+            let ancestor_vnode = visible_nodes.get(ancestor_vis.0)?;
+            let ancestor = tree.node(ancestor_vnode.id)?;
+
+            if let Some(grand_vis) = ancestor_vnode.parent_vis_idx {
                 let has_more_siblings = Self::has_more_visible_siblings(
-                    ancestor_id,
-                    grand_id,
+                    ancestor_vis,
+                    grand_vis,
                     last_visible_non_group_child,
                 );
+                let grand_node_id = visible_nodes[grand_vis.0].id;
                 let edge_style = tree
-                    .node(grand_id)
+                    .node(grand_node_id)
                     .and_then(|parent| parent.as_group().map(|group| group.kind.style()));
                 lineage.push(LineageSegment {
                     has_more_siblings,
@@ -56,33 +63,26 @@ impl Lineage {
                     is_group: ancestor.is_group(),
                 });
             }
-            current = ancestor.parent();
+            current_vis = ancestor_vnode.parent_vis_idx;
         }
 
         lineage.reverse();
         Some(Lineage {
             segments: lineage,
             is_last,
-            is_selected: selected == Some(node_id),
+            is_selected: selected_vis_idx == Some(vis_idx),
         })
     }
 
-    /// Returns true if the given node has any non-group sibling after it.
-    ///
-    /// # Notes
-    ///
-    /// - We use this when deciding `├──` vs `└──` and whether to draw `│` guides.
-    /// - Group headers are labels, so they don't keep the branch guide `│` alive.
-    /// - The sibling question is answered from a precomputed per-parent cache for the
-    ///   active visible slice, avoiding repeated sibling scans during rendering.
+    /// Returns true if the given visible position has any non-group sibling after it.
     fn has_more_visible_siblings(
-        node_id: NodeId,
-        parent_id: NodeId,
-        last_visible_non_group_child: Option<&[Option<NodeId>]>,
+        vis_idx: VisIdx,
+        parent_vis_idx: VisIdx,
+        last_visible_non_group_child: Option<&[Option<VisIdx>]>,
     ) -> bool {
         last_visible_non_group_child
-            .and_then(|children| children.get(parent_id.0))
+            .and_then(|children| children.get(parent_vis_idx.0))
             .and_then(|&last_child| last_child)
-            .is_some_and(|last_child| last_child != node_id)
+            .is_some_and(|last_child_vis| last_child_vis != vis_idx)
     }
 }

--- a/src/ops/tree/tui/widget/lineage.rs
+++ b/src/ops/tree/tui/widget/lineage.rs
@@ -28,17 +28,11 @@ impl Lineage {
         visible_nodes: &[VisibleNode],
         vis_idx: VisIdx,
         selected_vis_idx: Option<VisIdx>,
-        last_visible_non_group_child: Option<&[Option<VisIdx>]>,
     ) -> Option<Self> {
         let vnode = visible_nodes.get(vis_idx.0)?;
         tree.node(vnode.id)?;
 
-        let is_last = match vnode.parent_vis_idx {
-            Some(parent_vis) => {
-                !Self::has_more_visible_siblings(vis_idx, parent_vis, last_visible_non_group_child)
-            }
-            None => true,
-        };
+        let is_last = vnode.is_last_non_group_child;
 
         let mut lineage = Vec::new();
         let mut current_vis = vnode.parent_vis_idx;
@@ -48,11 +42,7 @@ impl Lineage {
             let ancestor = tree.node(ancestor_vnode.id)?;
 
             if let Some(grand_vis) = ancestor_vnode.parent_vis_idx {
-                let has_more_siblings = Self::has_more_visible_siblings(
-                    ancestor_vis,
-                    grand_vis,
-                    last_visible_non_group_child,
-                );
+                let has_more_siblings = !ancestor_vnode.is_last_non_group_child;
                 let grand_node_id = visible_nodes[grand_vis.0].id;
                 let edge_style = tree
                     .node(grand_node_id)
@@ -72,17 +62,5 @@ impl Lineage {
             is_last,
             is_selected: selected_vis_idx == Some(vis_idx),
         })
-    }
-
-    /// Returns true if the given visible position has any non-group sibling after it.
-    fn has_more_visible_siblings(
-        vis_idx: VisIdx,
-        parent_vis_idx: VisIdx,
-        last_visible_non_group_child: Option<&[Option<VisIdx>]>,
-    ) -> bool {
-        last_visible_non_group_child
-            .and_then(|children| children.get(parent_vis_idx.0))
-            .and_then(|&last_child| last_child)
-            .is_some_and(|last_child_vis| last_child_vis != vis_idx)
     }
 }

--- a/src/ops/tree/tui/widget/mod.rs
+++ b/src/ops/tree/tui/widget/mod.rs
@@ -12,7 +12,7 @@ use self::{breadcrumb::Breadcrumb, render::RenderContext};
 
 pub use self::{
     render::RenderOutput,
-    state::{SearchState, TreeWidgetState},
+    state::{SearchState, TreeWidgetState, VisIdx},
     style::TreeWidgetStyle,
 };
 
@@ -21,6 +21,7 @@ mod lineage;
 pub mod render;
 pub mod state;
 mod style;
+mod view_cache;
 mod viewport;
 
 /// A tree widget for displaying hierarchical dependencies.

--- a/src/ops/tree/tui/widget/render.rs
+++ b/src/ops/tree/tui/widget/render.rs
@@ -59,7 +59,6 @@ impl<'a, 's> RenderContext<'a, 's> {
         };
 
         self.state.ensure_visible_nodes(self.tree);
-        self.state.ensure_visible_metadata(self.tree);
 
         let total_lines = self.state.total_lines(self.tree);
         let selected_vpos = self.state.selected_virtual_pos();
@@ -136,13 +135,7 @@ impl<'a, 's> RenderContext<'a, 's> {
         let vnode = visible_nodes.get(vis_idx.0)?;
         let node_id = vnode.id;
         let node_data = self.tree.node(node_id)?;
-        let lineage = Lineage::build(
-            self.tree,
-            visible_nodes,
-            vis_idx,
-            selected_vis,
-            self.state.active_last_visible_non_group_child(),
-        )?;
+        let lineage = Lineage::build(self.tree, visible_nodes, vis_idx, selected_vis)?;
         let has_children = !node_data.children().is_empty();
         let is_open = self.state.open.get(node_id.0).copied().unwrap_or(false);
         let is_group = node_data.is_group();

--- a/src/ops/tree/tui/widget/render.rs
+++ b/src/ops/tree/tui/widget/render.rs
@@ -233,7 +233,7 @@ fn format_suffixes<'a>(node: &Dependency, style: &TreeWidgetStyle) -> Option<Vec
     }
 
     if node.is_proc_macro {
-        suffixes.push("proc-macro".to_string());
+        suffixes.push("proc-macro".into());
     }
 
     if suffixes.is_empty() {

--- a/src/ops/tree/tui/widget/render.rs
+++ b/src/ops/tree/tui/widget/render.rs
@@ -4,11 +4,11 @@ use ratatui::{
     widgets::Block,
 };
 
-use crate::core::{Dependency, DependencyNode, DependencyTree, NodeId};
+use crate::core::{Dependency, DependencyNode, DependencyTree};
 
 use super::{
     lineage::Lineage,
-    state::{TreeWidgetState, VisibleNode},
+    state::{TreeWidgetState, VisIdx, VisibleNode},
     style::TreeWidgetStyle,
     viewport::Viewport,
 };
@@ -54,36 +54,64 @@ impl<'a, 's> RenderContext<'a, 's> {
     }
 
     pub fn render(&mut self, area: Rect) -> RenderOutput<'a> {
-        let Some(selected_idx) = self.state.selected_position(self.tree) else {
+        if self.state.selected_position(self.tree).is_none() {
             return RenderOutput::default();
         };
 
-        // Keep the visible list borrowed from state instead of cloning it per frame.
         self.state.ensure_visible_nodes(self.tree);
-        let selected_line = selected_idx + 1;
-        let total_lines = self.state.active_visible_nodes().len();
+        self.state.ensure_visible_metadata(self.tree);
 
-        let mut viewport = Viewport::new(area, self.block).center_on(selected_line, total_lines, 1);
+        let total_lines = self.state.total_lines(self.tree);
+        let selected_vpos = self.state.selected_virtual_pos();
+        let prev_offset = self.state.viewport.offset;
+        let selected_vline = selected_vpos.map(|vp| vp.0).unwrap_or(0);
+        let mut viewport = Viewport::new(area, self.block).scroll_into_view(
+            selected_vline,
+            total_lines,
+            1,
+            prev_offset,
+        );
         self.state.update_viewport(viewport);
 
-        let context_lines = {
+        // Context lines: walk parent_vis_idx from the node at viewport.offset.min(max_offset),
+        // matching the original context bar behavior.
+        let context_vpos = viewport.offset.min(viewport.max_offset);
+        let context_lines = if context_vpos > 0 {
             let visible_nodes = self.state.active_visible_nodes();
-            self.render_context_lines(visible_nodes, viewport.offset.min(viewport.max_offset))
+            let selected_vis = self.state.selected_position_cached();
+            if let Some(context_idx) = visible_nodes
+                .iter()
+                .position(|n| n.virtual_pos.0 == context_vpos)
+            {
+                self.render_context_lines(visible_nodes, context_idx, selected_vis)
+            } else {
+                Vec::new()
+            }
+        } else {
+            Vec::new()
         };
 
         let content_height = viewport.height.saturating_sub(context_lines.len());
-
         viewport.clamp_offset(total_lines, context_lines.len());
         self.state.update_viewport(viewport);
 
-        let start_flat = viewport.offset;
+        // Render viewport rows: find nodes with virtual_pos in [viewport.offset, offset + content_height).
+        let render_start_vpos = viewport.offset;
+        let render_end_vpos = viewport.offset + content_height;
         let mut lines = Vec::with_capacity(content_height);
-        let end_flat = (start_flat + content_height).min(total_lines);
         {
             let visible_nodes = self.state.active_visible_nodes();
-            for flat_id in start_flat..end_flat {
-                if let Some(node) = visible_nodes.get(flat_id)
-                    && let Some(line) = self.render_node(node.id, false)
+            let selected_vis = self.state.selected_position_cached();
+            for (i, vnode) in visible_nodes.iter().enumerate() {
+                if vnode.virtual_pos.0 < render_start_vpos {
+                    continue;
+                }
+                if vnode.virtual_pos.0 >= render_end_vpos {
+                    break;
+                }
+                let vis = VisIdx(i);
+                if let Some(line) =
+                    self.render_visible_node(visible_nodes, vis, selected_vis, false)
                 {
                     lines.push(line);
                 }
@@ -98,19 +126,28 @@ impl<'a, 's> RenderContext<'a, 's> {
         }
     }
 
-    pub fn render_node(&self, node_id: NodeId, context_lines: bool) -> Option<Line<'a>> {
+    pub fn render_visible_node(
+        &self,
+        visible_nodes: &[VisibleNode],
+        vis_idx: VisIdx,
+        selected_vis: Option<VisIdx>,
+        context_lines: bool,
+    ) -> Option<Line<'a>> {
+        let vnode = visible_nodes.get(vis_idx.0)?;
+        let node_id = vnode.id;
         let node_data = self.tree.node(node_id)?;
         let lineage = Lineage::build(
             self.tree,
-            node_id,
-            self.state.selected,
+            visible_nodes,
+            vis_idx,
+            selected_vis,
             self.state.active_last_visible_non_group_child(),
         )?;
         let has_children = !node_data.children().is_empty();
         let is_open = self.state.open.get(node_id.0).copied().unwrap_or(false);
         let is_group = node_data.is_group();
 
-        let is_root = node_data.parent().is_none();
+        let is_root = vnode.parent_vis_idx.is_none();
         let show_connector = !is_root;
 
         let mut spans = Vec::new();
@@ -150,9 +187,10 @@ impl<'a, 's> RenderContext<'a, 's> {
                 } else {
                     self.style.branch_symbol
                 };
-                let parent_group_style = node_data
-                    .parent()
-                    .and_then(|parent_id| self.tree.node(parent_id))
+                let parent_group_style = vnode
+                    .parent_vis_idx
+                    .and_then(|pvis| visible_nodes.get(pvis.0))
+                    .and_then(|pvnode| self.tree.node(pvnode.id))
                     .and_then(|parent| parent.as_group().map(|group| group.kind.style()));
                 let connector_style = parent_group_style.unwrap_or(self.style.style);
                 spans.push(Span::styled(connector, connector_style));
@@ -197,29 +235,37 @@ impl<'a, 's> RenderContext<'a, 's> {
         Some(Line::from(spans))
     }
 
-    fn render_context_lines(&self, visible_nodes: &[VisibleNode], offset: usize) -> Vec<Line<'a>> {
-        if offset == 0 {
-            return Vec::new();
-        }
-
-        let Some(first_visible) = visible_nodes.get(offset) else {
+    /// Renders context lines by walking the parent chain from the first window-zone node.
+    fn render_context_lines(
+        &self,
+        visible_nodes: &[VisibleNode],
+        first_window_idx: usize,
+        selected_vis: Option<VisIdx>,
+    ) -> Vec<Line<'a>> {
+        let Some(first_visible) = visible_nodes.get(first_window_idx) else {
             return Vec::new();
         };
 
-        // Collect ancestors bottom → top
-        let mut ancestors = Vec::new();
-        let mut current = self.tree.node(first_visible.id).and_then(|n| n.parent());
+        // Collect ancestor visible indices bottom → top.
+        let mut ancestor_vis_indices: Vec<VisIdx> = Vec::new();
+        let mut current_vis = first_visible.parent_vis_idx;
 
-        while let Some(id) = current {
-            ancestors.push(id);
-            current = self.tree.node(id).and_then(|n| n.parent());
+        while let Some(vis_idx) = current_vis {
+            if let Some(vnode) = visible_nodes.get(vis_idx.0) {
+                ancestor_vis_indices.push(vis_idx);
+                current_vis = vnode.parent_vis_idx;
+            } else {
+                break;
+            }
         }
 
-        // Render top → bottom, limited
-        ancestors
+        // Render top → bottom.
+        ancestor_vis_indices
             .into_iter()
             .rev()
-            .filter_map(|id| self.render_node(id, true))
+            .filter_map(|vis_idx| {
+                self.render_visible_node(visible_nodes, vis_idx, selected_vis, true)
+            })
             .collect()
     }
 }
@@ -229,11 +275,11 @@ fn format_suffixes<'a>(node: &Dependency, style: &TreeWidgetStyle) -> Option<Vec
     let mut suffixes = Vec::new();
 
     if let Some(path) = &node.manifest_dir {
-        suffixes.push(path.clone());
+        suffixes.push(path.to_string());
     }
 
     if node.is_proc_macro {
-        suffixes.push("proc-macro".into());
+        suffixes.push("proc-macro".to_string());
     }
 
     if suffixes.is_empty() {

--- a/src/ops/tree/tui/widget/state.rs
+++ b/src/ops/tree/tui/widget/state.rs
@@ -2,9 +2,19 @@ use rustc_hash::FxHashSet;
 
 use crate::core::{DependencyNode, DependencyTree, NodeId};
 
-use super::view_cache::{ViewCache, materialize_window};
+use super::view_cache::ViewCache;
 use super::viewport::Viewport;
 
+/// The widget uses three different index spaces:
+///
+/// - [`NodeId`] identifies a node in the arena-backed dependency graph.
+/// - [`VirtualPos`] identifies a row in the fully flattened virtual tree for
+///   the current `(open, filter)` state.
+/// - [`VisIdx`] identifies a row inside the small materialized window stored in
+///   the active [`ViewCache`].
+///
+/// Keeping these separate avoids mixing graph identity, virtual scroll
+/// position, and cache-local row indices.
 /// Index into a flattened visible-node cache.
 ///
 /// Distinguishes visible-cache positions from [`NodeId`] at the type level
@@ -66,6 +76,10 @@ pub struct VisibleNode {
     pub next_sibling: Option<VisIdx>,
     /// Previous sibling in the same visible cache sharing the same parent.
     pub prev_sibling: Option<VisIdx>,
+    /// Whether this node is the last non-group child of its parent in the
+    /// full virtual stream under the current open/filter (not just within
+    /// the materialized window). Drives the `└─` vs `├─` decision.
+    pub is_last_non_group_child: bool,
 }
 
 /// Search result payload computed off the UI thread.
@@ -100,10 +114,7 @@ impl Default for TreeWidgetState {
             viewport: Viewport::default(),
             subtree_dirty: true,
             dirty: true,
-            normal: ViewCache {
-                metadata_dirty: true,
-                ..ViewCache::default()
-            },
+            normal: ViewCache::default(),
             search: ViewCache::default(),
             search_visible_nodes: Vec::new(),
             search_matches: Vec::new(),
@@ -221,11 +232,6 @@ impl TreeWidgetState {
         }
 
         search_state
-    }
-
-    /// Returns the last visible non-group child per parent for the active view.
-    pub fn active_last_visible_non_group_child(&self) -> Option<&[Option<VisIdx>]> {
-        Some(&self.active_cache().last_non_group_child)
     }
 
     /// Moves the selection to the next visible dependency.
@@ -363,36 +369,31 @@ impl TreeWidgetState {
 
     /// Moves the selection to the next sibling, if any.
     pub fn select_next_sibling(&mut self, tree: &DependencyTree) {
-        if !self.ensure_selection(tree) {
-            return;
-        }
-        self.ensure_visible_metadata(tree);
-        let Some(vpos) = self.selected_virtual_pos else {
-            return;
-        };
-        if let Some((_, vnode)) = self.find_by_vpos(vpos)
-            && let Some(next) = vnode.next_sibling
-            && let Some(next_node) = self.active_visible_nodes().get(next.0)
-        {
-            self.selected_virtual_pos = Some(next_node.virtual_pos);
-            self.dirty = true;
-        }
+        self.select_sibling(tree, |n| n.next_sibling);
     }
 
     /// Moves the selection to the previous sibling, if any.
     pub fn select_previous_sibling(&mut self, tree: &DependencyTree) {
+        self.select_sibling(tree, |n| n.prev_sibling);
+    }
+
+    fn select_sibling(
+        &mut self,
+        tree: &DependencyTree,
+        pick: impl Fn(&VisibleNode) -> Option<VisIdx>,
+    ) {
         if !self.ensure_selection(tree) {
             return;
         }
-        self.ensure_visible_metadata(tree);
         let Some(vpos) = self.selected_virtual_pos else {
             return;
         };
+
         if let Some((_, vnode)) = self.find_by_vpos(vpos)
-            && let Some(prev) = vnode.prev_sibling
-            && let Some(prev_node) = self.active_visible_nodes().get(prev.0)
+            && let Some(sibling) = pick(vnode)
+            && let Some(sibling_node) = self.active_visible_nodes().get(sibling.0)
         {
-            self.selected_virtual_pos = Some(prev_node.virtual_pos);
+            self.selected_virtual_pos = Some(sibling_node.virtual_pos);
             self.dirty = true;
         }
     }
@@ -487,11 +488,11 @@ impl TreeWidgetState {
 
         self.ensure_node_capacity(tree);
 
-        self.normal.recompute_subtree_sizes(tree, &self.open, None);
+        self.normal.refresh_sizes(tree, &self.open, None);
 
         if self.is_searching() {
             self.search
-                .recompute_subtree_sizes(tree, &self.open, Some(&self.search_visible_nodes));
+                .refresh_sizes(tree, &self.open, Some(&self.search_visible_nodes));
         }
 
         self.subtree_dirty = false;
@@ -506,12 +507,6 @@ impl TreeWidgetState {
         self.ensure_subtree_sizes(tree);
         self.rebuild_visible(tree);
         self.dirty = false;
-    }
-
-    /// Lazily computes sibling links and last-child map for the active visible cache.
-    pub fn ensure_visible_metadata(&mut self, tree: &DependencyTree) {
-        self.normal.ensure_metadata(tree);
-        self.search.ensure_metadata(tree);
     }
 
     /// Returns the currently active visible slice.
@@ -574,27 +569,20 @@ impl TreeWidgetState {
         // Materialize enough for viewport + buffer for scrolling.
         let window_count = viewport_height * 2;
 
-        let (sizes, filter): (&[usize], Option<&[bool]>) = if self.is_searching() {
-            (&self.search.subtree_sizes, Some(&self.search_visible_nodes))
+        let searching = self.is_searching();
+        let (cache, filter): (&mut ViewCache, Option<&[bool]>) = if searching {
+            (&mut self.search, Some(&self.search_visible_nodes))
         } else {
-            (&self.normal.subtree_sizes, None)
+            (&mut self.normal, None)
         };
 
-        let result = materialize_window(
+        cache.rematerialize(
             tree,
             &self.open,
-            sizes,
             filter,
             tree.roots(),
-            window_start,
-            window_count,
+            window_start..window_start + window_count,
         );
-
-        if self.is_searching() {
-            self.search.apply_materialization(result);
-        } else {
-            self.normal.apply_materialization(result);
-        }
     }
 
     /// Rebuilds the search view after applying new search state.
@@ -605,7 +593,7 @@ impl TreeWidgetState {
         }
 
         self.search
-            .recompute_subtree_sizes(tree, &self.open, Some(&self.search_visible_nodes));
+            .refresh_sizes(tree, &self.open, Some(&self.search_visible_nodes));
 
         // Clamp selection to search view bounds.
         if let Some(vpos) = self.selected_virtual_pos

--- a/src/ops/tree/tui/widget/state.rs
+++ b/src/ops/tree/tui/widget/state.rs
@@ -148,7 +148,7 @@ impl TreeWidgetState {
 
         let mut search_state = SearchState::new(tree.nodes.len());
 
-        for &node_id in tree.crate_nodes() {
+        for node_id in tree.crate_nodes() {
             let Some(DependencyNode::Crate(dependency)) = tree.node(node_id) else {
                 continue;
             };

--- a/src/ops/tree/tui/widget/state.rs
+++ b/src/ops/tree/tui/widget/state.rs
@@ -1,6 +1,26 @@
+use rustc_hash::FxHashSet;
+
 use crate::core::{DependencyNode, DependencyTree, NodeId};
 
+use super::view_cache::{ViewCache, materialize_window};
 use super::viewport::Viewport;
+
+/// Index into a flattened visible-node cache.
+///
+/// Distinguishes visible-cache positions from [`NodeId`] at the type level
+/// so the two kinds of `usize` index cannot be accidentally mixed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct VisIdx(pub usize);
+
+/// Position in the full virtual (fully-flattened) tree under the current
+/// `(open, filter)` configuration.
+///
+/// Distinct from [`VisIdx`] (which indexes the *materialized* window) and
+/// from [`NodeId`] (which identifies a node in the arena). Selection is
+/// stored as a `VirtualPos` so a shared crate appearing at multiple DAG
+/// positions has unambiguous identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct VirtualPos(pub usize);
 
 /// [`TreeWidget`] state that tracks open nodes and the current selection.
 ///
@@ -9,8 +29,18 @@ use super::viewport::Viewport;
 pub struct TreeWidgetState {
     /// Open/closed state indexed by node id.
     pub open: Vec<bool>,
-    /// Currently selected node.
-    pub selected: Option<NodeId>,
+    /// Virtual position of the selected node in the full flattened tree.
+    selected_virtual_pos: Option<VirtualPos>,
+    /// Current viewport.
+    pub viewport: Viewport,
+    /// Whether subtree sizes need recomputation.
+    subtree_dirty: bool,
+    /// Whether the visible cache needs re-materialization.
+    dirty: bool,
+    /// Materialized state for the normal (unfiltered) view.
+    normal: ViewCache,
+    /// Materialized state for the search-filtered view.
+    search: ViewCache,
     /// Nodes kept visible by the active search, indexed by node id.
     search_visible_nodes: Vec<bool>,
     /// Nodes whose crate names directly match the active search query, indexed by node id.
@@ -19,27 +49,23 @@ pub struct TreeWidgetState {
     search_visible_ids: Vec<NodeId>,
     /// Node ids whose `search_matches` bit is currently set, used for cheap resets and refinement.
     search_match_ids: Vec<NodeId>,
-    /// Current viewport.
-    pub viewport: Viewport,
-    /// Flattened visible tree for the current expansion state.
-    visible_cache: Vec<VisibleNode>,
-    /// Last visible non-group child per parent in `visible_cache`, indexed by parent node id.
-    visible_last_non_group_child: Vec<Option<NodeId>>,
-    /// Flattened visible tree restricted to the active search result.
-    search_visible_cache: Vec<VisibleNode>,
-    /// Last visible non-group child per parent in `search_visible_cache`, indexed by parent node id.
-    search_visible_last_non_group_child: Vec<Option<NodeId>>,
-    /// Indicates whether the visible cache is outdated.
-    dirty: bool,
 }
 
-/// Visible node metadata used for navigation.
+/// Visible node metadata used for navigation and rendering.
 #[derive(Debug, Clone, Copy)]
 pub struct VisibleNode {
     /// Node identifier.
     pub id: NodeId,
     /// Depth in the tree hierarchy.
     pub depth: usize,
+    /// Position in the full virtual flattened list.
+    pub virtual_pos: VirtualPos,
+    /// Index of the parent in the same visible cache, or `None` for roots.
+    pub parent_vis_idx: Option<VisIdx>,
+    /// Next sibling in the same visible cache sharing the same parent.
+    pub next_sibling: Option<VisIdx>,
+    /// Previous sibling in the same visible cache sharing the same parent.
+    pub prev_sibling: Option<VisIdx>,
 }
 
 /// Search result payload computed off the UI thread.
@@ -70,26 +96,56 @@ impl Default for TreeWidgetState {
     fn default() -> Self {
         Self {
             open: Vec::new(),
-            visible_last_non_group_child: Vec::new(),
-            selected: None,
+            selected_virtual_pos: None,
+            viewport: Viewport::default(),
+            subtree_dirty: true,
+            dirty: true,
+            normal: ViewCache {
+                metadata_dirty: true,
+                ..ViewCache::default()
+            },
+            search: ViewCache::default(),
             search_visible_nodes: Vec::new(),
             search_matches: Vec::new(),
             search_visible_ids: Vec::new(),
             search_match_ids: Vec::new(),
-            viewport: Viewport::default(),
-            visible_cache: Vec::new(),
-            search_visible_cache: Vec::new(),
-            search_visible_last_non_group_child: Vec::new(),
-            dirty: true,
         }
     }
 }
 
 impl TreeWidgetState {
-    /// Grows all node-indexed caches to match the current tree size.
+    /// Finds the node at the given virtual position in the active cache.
+    fn find_by_vpos(&self, vpos: VirtualPos) -> Option<(VisIdx, &VisibleNode)> {
+        self.active_visible_nodes()
+            .iter()
+            .enumerate()
+            .find(|(_, n)| n.virtual_pos == vpos)
+            .map(|(i, n)| (VisIdx(i), n))
+    }
+
+    /// Returns the `NodeId` of the currently selected visible position.
     ///
-    /// The widget uses parallel `Vec`s keyed by `NodeId` instead of hash maps/sets so
-    /// search, expansion, and render-time membership checks become cheap indexed loads.
+    /// Returns `None` if nothing is selected or the cache doesn't contain the
+    /// selected position (call [`ensure_visible_nodes`] first).
+    pub fn selected_node_id(&self) -> Option<NodeId> {
+        let vpos = self.selected_virtual_pos?;
+        self.find_by_vpos(vpos).map(|(_, n)| n.id)
+    }
+
+    /// Sets the selection to the virtual position of the given `NodeId`.
+    ///
+    /// Requires a DFS walk using subtree sizes to locate the first occurrence.
+    pub fn set_selected_node_id(&mut self, tree: &DependencyTree, id: NodeId) {
+        self.ensure_subtree_sizes(tree);
+        let sizes = self.active_subtree_sizes();
+        let filter = self.active_filter();
+        let roots = tree.roots();
+
+        self.selected_virtual_pos = find_virtual_pos(tree, &self.open, sizes, filter, roots, id);
+        self.dirty = true;
+    }
+
+    /// Grows all node-indexed caches to match the current tree size.
     fn ensure_node_capacity(&mut self, tree: &DependencyTree) {
         let len = tree.nodes.len();
         if self.open.len() == len {
@@ -99,8 +155,6 @@ impl TreeWidgetState {
         self.open.resize(len, false);
         self.search_visible_nodes.resize(len, false);
         self.search_matches.resize(len, false);
-        self.visible_last_non_group_child.resize(len, None);
-        self.search_visible_last_non_group_child.resize(len, None);
     }
 
     /// Clears any active search filtering state.
@@ -111,8 +165,9 @@ impl TreeWidgetState {
         for node_id in self.search_match_ids.drain(..) {
             self.search_matches[node_id.0] = false;
         }
-        self.search_visible_cache.clear();
-        self.search_visible_last_non_group_child.fill(None);
+        self.search.clear();
+        // Rematerialize the main view with the current selection.
+        self.dirty = true;
     }
 
     /// Returns whether a node directly matches the active search query.
@@ -127,7 +182,7 @@ impl TreeWidgetState {
         self.search_matches = search_state.matches;
         self.search_visible_ids = search_state.visible_ids;
         self.search_match_ids = search_state.match_ids;
-        self.rebuild_filtered_visible(tree);
+        self.rebuild_search_view(tree);
     }
 
     /// Updates search-filtered nodes by matching crate names case-sensitively.
@@ -169,15 +224,8 @@ impl TreeWidgetState {
     }
 
     /// Returns the last visible non-group child per parent for the active view.
-    ///
-    /// This lets the render path answer "is this the final visible branch?" with one
-    /// indexed lookup rather than rescanning siblings in the current filtered slice.
-    pub fn active_last_visible_non_group_child(&self) -> Option<&[Option<NodeId>]> {
-        if self.search_visible_cache.is_empty() {
-            Some(&self.visible_last_non_group_child)
-        } else {
-            Some(&self.search_visible_last_non_group_child)
-        }
+    pub fn active_last_visible_non_group_child(&self) -> Option<&[Option<VisIdx>]> {
+        Some(&self.active_cache().last_non_group_child)
     }
 
     /// Moves the selection to the next visible dependency.
@@ -186,22 +234,13 @@ impl TreeWidgetState {
             return;
         }
 
-        let selected = match self.selected {
-            Some(id) => id,
-            None => return,
+        let Some(vpos) = self.selected_virtual_pos else {
+            return;
         };
-
-        let next = {
-            let visible = self.visible_nodes(tree);
-            let Some(current_index) = Self::selected_index(visible, selected) else {
-                return;
-            };
-
-            visible.get(current_index + 1).map(|node| node.id)
-        };
-
-        if let Some(next_id) = next {
-            self.selected = Some(next_id);
+        let total = self.active_total_virtual_lines();
+        if vpos.0 + 1 < total {
+            self.selected_virtual_pos = Some(VirtualPos(vpos.0 + 1));
+            self.dirty = true;
         }
     }
 
@@ -211,26 +250,12 @@ impl TreeWidgetState {
             return;
         }
 
-        let selected = match self.selected {
-            Some(id) => id,
-            None => return,
+        let Some(vpos) = self.selected_virtual_pos else {
+            return;
         };
-
-        let previous = {
-            let visible = self.visible_nodes(tree);
-            let Some(current_index) = Self::selected_index(visible, selected) else {
-                return;
-            };
-
-            if current_index > 0 {
-                Some(visible[current_index - 1].id)
-            } else {
-                None
-            }
-        };
-
-        if let Some(previous_id) = previous {
-            self.selected = Some(previous_id);
+        if vpos.0 > 0 {
+            self.selected_virtual_pos = Some(VirtualPos(vpos.0 - 1));
+            self.dirty = true;
         }
     }
 
@@ -239,12 +264,11 @@ impl TreeWidgetState {
         if !self.ensure_selection(tree) {
             return;
         }
-        let selected = match self.selected {
-            Some(id) => id,
-            None => return,
+        self.ensure_visible_nodes(tree);
+        let Some(node_id) = self.selected_node_id() else {
+            return;
         };
-
-        let Some(node) = tree.node(selected) else {
+        let Some(node) = tree.node(node_id) else {
             return;
         };
 
@@ -252,7 +276,7 @@ impl TreeWidgetState {
             return;
         }
 
-        if self.open[selected.0] {
+        if self.open[node_id.0] {
             self.collapse(tree);
         } else {
             self.expand(tree);
@@ -264,13 +288,14 @@ impl TreeWidgetState {
         if !self.ensure_selection(tree) {
             return;
         }
-
-        let selected = match self.selected {
-            Some(id) => id,
-            None => return,
+        let Some(vpos) = self.selected_virtual_pos else {
+            return;
         };
-
-        let Some(node) = tree.node(selected) else {
+        self.ensure_visible_nodes(tree);
+        let Some(node_id) = self.selected_node_id() else {
+            return;
+        };
+        let Some(node) = tree.node(node_id) else {
             return;
         };
 
@@ -278,15 +303,19 @@ impl TreeWidgetState {
             return;
         }
 
-        if !self.open[selected.0] {
-            self.open[selected.0] = true;
-            self.insert_descendants(selected, tree);
-            self.rebuild_filtered_visible(tree);
-            self.dirty = false;
+        if !self.open[node_id.0] {
+            self.open[node_id.0] = true;
+            self.subtree_dirty = true;
+            self.dirty = true;
             return;
         }
 
-        self.selected = Some(node.children()[0]);
+        // Already open — move into first child (next virtual position).
+        let total = self.active_total_virtual_lines();
+        if vpos.0 + 1 < total {
+            self.selected_virtual_pos = Some(VirtualPos(vpos.0 + 1));
+            self.dirty = true;
+        }
     }
 
     /// Collapses the selected node or moves focus to its parent when already closed.
@@ -294,95 +323,77 @@ impl TreeWidgetState {
         if !self.ensure_selection(tree) {
             return;
         }
-
-        let selected = match self.selected {
-            Some(id) => id,
-            None => return,
+        self.ensure_visible_nodes(tree);
+        let Some(node_id) = self.selected_node_id() else {
+            return;
         };
-
-        let Some(node) = tree.node(selected) else {
+        let Some(node) = tree.node(node_id) else {
             return;
         };
 
-        // If the node has children and is open, close it first.
-        if !node.children().is_empty() && self.open[selected.0] {
-            self.open[selected.0] = false;
-            self.prune_descendants(selected);
-            self.rebuild_filtered_visible(tree);
-            self.dirty = false;
+        // If the node has children and is open, close it.
+        if !node.children().is_empty() && self.open[node_id.0] {
+            self.open[node_id.0] = false;
+            self.subtree_dirty = true;
+            self.dirty = true;
             return;
         }
 
-        // Otherwise move focus to its parent when possible.
-        if let Some(parent) = node.parent() {
-            self.selected = Some(parent);
-        }
+        // Otherwise move focus to parent.
+        self.select_parent(tree);
     }
 
     /// Moves the selection to the parent node, if any.
     pub fn select_parent(&mut self, tree: &DependencyTree) {
-        let Some(selected) = self.selected else {
+        if !self.ensure_selection(tree) {
+            return;
+        }
+        // Find the selected node in the cache and read its parent's virtual_pos.
+        let Some(vpos) = self.selected_virtual_pos else {
             return;
         };
-
-        if let Some(node) = tree.node(selected)
-            && let Some(parent) = node.parent()
+        if let Some((_, vnode)) = self.find_by_vpos(vpos)
+            && let Some(parent_vis) = vnode.parent_vis_idx
+            && let Some(parent_node) = self.active_visible_nodes().get(parent_vis.0)
         {
-            self.selected = Some(parent);
+            self.selected_virtual_pos = Some(parent_node.virtual_pos);
+            self.dirty = true;
         }
     }
 
     /// Moves the selection to the next sibling, if any.
     pub fn select_next_sibling(&mut self, tree: &DependencyTree) {
-        let Some(selected) = self.selected else {
+        if !self.ensure_selection(tree) {
+            return;
+        }
+        self.ensure_visible_metadata(tree);
+        let Some(vpos) = self.selected_virtual_pos else {
             return;
         };
-        let Some(node) = tree.node(selected) else {
-            return;
-        };
-
-        let siblings: &[NodeId] = if let Some(parent) = node.parent() {
-            let Some(parent_node) = tree.node(parent) else {
-                return;
-            };
-            parent_node.children()
-        } else {
-            tree.roots()
-        };
-
-        let Some(pos) = siblings.iter().position(|&id| id == selected) else {
-            return;
-        };
-
-        if pos + 1 < siblings.len() {
-            self.selected = Some(siblings[pos + 1]);
+        if let Some((_, vnode)) = self.find_by_vpos(vpos)
+            && let Some(next) = vnode.next_sibling
+            && let Some(next_node) = self.active_visible_nodes().get(next.0)
+        {
+            self.selected_virtual_pos = Some(next_node.virtual_pos);
+            self.dirty = true;
         }
     }
 
     /// Moves the selection to the previous sibling, if any.
     pub fn select_previous_sibling(&mut self, tree: &DependencyTree) {
-        let Some(selected) = self.selected else {
+        if !self.ensure_selection(tree) {
+            return;
+        }
+        self.ensure_visible_metadata(tree);
+        let Some(vpos) = self.selected_virtual_pos else {
             return;
         };
-        let Some(node) = tree.node(selected) else {
-            return;
-        };
-
-        let siblings: &[NodeId] = if let Some(parent) = node.parent() {
-            let Some(parent_node) = tree.node(parent) else {
-                return;
-            };
-            parent_node.children()
-        } else {
-            tree.roots()
-        };
-
-        let Some(pos) = siblings.iter().position(|&id| id == selected) else {
-            return;
-        };
-
-        if pos > 0 {
-            self.selected = Some(siblings[pos - 1]);
+        if let Some((_, vnode)) = self.find_by_vpos(vpos)
+            && let Some(prev) = vnode.prev_sibling
+            && let Some(prev_node) = self.active_visible_nodes().get(prev.0)
+        {
+            self.selected_virtual_pos = Some(prev_node.virtual_pos);
+            self.dirty = true;
         }
     }
 
@@ -403,35 +414,18 @@ impl TreeWidgetState {
         if !self.ensure_selection(tree) {
             return;
         }
-
-        let selected = match self.selected {
-            Some(id) => id,
-            None => return,
+        let Some(vpos) = self.selected_virtual_pos else {
+            return;
         };
+        let total = self.active_total_virtual_lines() as isize;
+        if total == 0 {
+            return;
+        }
 
-        let next = {
-            let visible = self.visible_nodes(tree);
-            let Some(current_index) = Self::selected_index(visible, selected) else {
-                return;
-            };
-
-            let len = visible.len() as isize;
-            if len == 0 {
-                return;
-            }
-
-            let mut next_index = current_index as isize + delta;
-            if next_index < 0 {
-                next_index = 0;
-            } else if next_index >= len {
-                next_index = len - 1;
-            }
-
-            visible.get(next_index as usize).map(|node| node.id)
-        };
-
-        if let Some(next_id) = next {
-            self.selected = Some(next_id);
+        let next = (vpos.0 as isize + delta).clamp(0, total - 1) as usize;
+        if next != vpos.0 {
+            self.selected_virtual_pos = Some(VirtualPos(next));
+            self.dirty = true;
         }
     }
 
@@ -442,72 +436,41 @@ impl TreeWidgetState {
         }
         self.ensure_node_capacity(tree);
         self.open.fill(false);
+        let mut ancestors = FxHashSet::default();
         for &root in tree.roots() {
-            self.open_node(tree, root, 1, max_depth);
+            self.open_node(tree, root, 1, max_depth, &mut ancestors);
         }
+        self.subtree_dirty = true;
         self.dirty = true;
         self.ensure_selection(tree);
     }
 
-    fn open_node(&mut self, tree: &DependencyTree, id: NodeId, depth: usize, max_depth: usize) {
+    fn open_node(
+        &mut self,
+        tree: &DependencyTree,
+        id: NodeId,
+        depth: usize,
+        max_depth: usize,
+        ancestors: &mut FxHashSet<NodeId>,
+    ) {
         if depth >= max_depth {
             return;
         }
 
         if let Some(node) = tree.node(id) {
-            // Do not mark leaves as open to avoid confusing collapse semantics.
             if node.children().is_empty() {
                 return;
             }
 
             self.open[id.0] = true;
+            ancestors.insert(id);
             for &child in node.children() {
-                self.open_node(tree, child, depth + 1, max_depth);
+                if !ancestors.contains(&child) {
+                    self.open_node(tree, child, depth + 1, max_depth, ancestors);
+                }
             }
+            ancestors.remove(&id);
         }
-    }
-
-    /// Removes all descendants of `id` from the visible cache in-place.
-    fn prune_descendants(&mut self, id: NodeId) {
-        let Some(start) = self.visible_cache.iter().position(|node| node.id == id) else {
-            return;
-        };
-        let Some(depth) = self.visible_cache.get(start).map(|node| node.depth) else {
-            return;
-        };
-
-        let first_descendant = start + 1;
-        if first_descendant >= self.visible_cache.len() {
-            return;
-        }
-
-        let end = self.visible_cache[first_descendant..]
-            .iter()
-            .position(|node| node.depth <= depth)
-            .map(|offset| first_descendant + offset)
-            .unwrap_or(self.visible_cache.len());
-
-        self.visible_cache.drain(first_descendant..end);
-    }
-
-    /// Inserts the visible descendants of `id` into the cache in-place.
-    fn insert_descendants(&mut self, id: NodeId, tree: &DependencyTree) {
-        let Some(start) = self.visible_cache.iter().position(|node| node.id == id) else {
-            return;
-        };
-        let Some(depth) = self.visible_cache.get(start).map(|node| node.depth) else {
-            return;
-        };
-
-        let mut subtree = Vec::new();
-        Self::collect_visible(&self.open, tree, id, depth, &mut subtree);
-        if subtree.len() <= 1 {
-            return;
-        }
-
-        let insert_at = start + 1;
-        self.visible_cache
-            .splice(insert_at..insert_at, subtree.into_iter().skip(1));
     }
 
     /// Returns cached visible nodes along with their depth in the hierarchy.
@@ -516,145 +479,237 @@ impl TreeWidgetState {
         self.active_visible_nodes()
     }
 
+    /// Recomputes subtree sizes if dirty.
+    fn ensure_subtree_sizes(&mut self, tree: &DependencyTree) {
+        if !self.subtree_dirty {
+            return;
+        }
+
+        self.ensure_node_capacity(tree);
+
+        self.normal.recompute_subtree_sizes(tree, &self.open, None);
+
+        if self.is_searching() {
+            self.search
+                .recompute_subtree_sizes(tree, &self.open, Some(&self.search_visible_nodes));
+        }
+
+        self.subtree_dirty = false;
+    }
+
     /// Rebuilds the visible caches lazily when tree openness has changed.
     pub fn ensure_visible_nodes(&mut self, tree: &DependencyTree) {
-        if self.dirty {
-            self.rebuild_visible(tree);
-            self.dirty = false;
+        if !self.dirty && !self.subtree_dirty {
+            return;
         }
+
+        self.ensure_subtree_sizes(tree);
+        self.rebuild_visible(tree);
+        self.dirty = false;
+    }
+
+    /// Lazily computes sibling links and last-child map for the active visible cache.
+    pub fn ensure_visible_metadata(&mut self, tree: &DependencyTree) {
+        self.normal.ensure_metadata(tree);
+        self.search.ensure_metadata(tree);
     }
 
     /// Returns the currently active visible slice.
-    ///
-    /// Search reuses the main visible cache and layers a filtered slice on top of it, so
-    /// callers can treat both modes uniformly.
     pub fn active_visible_nodes(&self) -> &[VisibleNode] {
-        if self.search_visible_cache.is_empty() {
-            &self.visible_cache
+        &self.active_cache().nodes
+    }
+
+    /// Returns the total virtual line count for the active view.
+    fn active_total_virtual_lines(&self) -> usize {
+        self.active_cache().total_virtual_lines
+    }
+
+    /// Returns the active subtree sizes slice.
+    fn active_subtree_sizes(&self) -> &[usize] {
+        if self.is_searching() && !self.search.subtree_sizes.is_empty() {
+            &self.search.subtree_sizes
         } else {
-            &self.search_visible_cache
+            &self.normal.subtree_sizes
+        }
+    }
+
+    /// Returns whether a search filter is currently active.
+    fn is_searching(&self) -> bool {
+        !self.search_match_ids.is_empty()
+    }
+
+    /// Returns the active ViewCache (search if searching, normal otherwise).
+    fn active_cache(&self) -> &ViewCache {
+        if self.is_searching() {
+            &self.search
+        } else {
+            &self.normal
+        }
+    }
+
+    /// Returns the active filter, if searching.
+    fn active_filter(&self) -> Option<&[bool]> {
+        if self.is_searching() {
+            Some(&self.search_visible_nodes)
+        } else {
+            None
         }
     }
 
     fn rebuild_visible(&mut self, tree: &DependencyTree) {
-        self.visible_cache.clear();
-        let open = &self.open;
-        for &root in tree.roots() {
-            Self::collect_visible(open, tree, root, 0, &mut self.visible_cache);
-        }
-        Self::populate_last_non_group_child_map(
+        let vpos = self.selected_virtual_pos.unwrap_or(VirtualPos(0));
+
+        // Use viewport height if known, otherwise a generous default.
+        let viewport_height = if self.viewport.height > 0 {
+            self.viewport.height
+        } else {
+            50
+        };
+
+        // Estimate window_start from the selected position, with generous
+        // buffer to ensure the materialized window covers what render needs.
+        // Start well before the selection so ancestor prefix nodes are included.
+        let window_start = vpos.0.saturating_sub(viewport_height);
+
+        // Materialize enough for viewport + buffer for scrolling.
+        let window_count = viewport_height * 2;
+
+        let (sizes, filter): (&[usize], Option<&[bool]>) = if self.is_searching() {
+            (&self.search.subtree_sizes, Some(&self.search_visible_nodes))
+        } else {
+            (&self.normal.subtree_sizes, None)
+        };
+
+        let result = materialize_window(
             tree,
-            &self.visible_cache,
-            &mut self.visible_last_non_group_child,
+            &self.open,
+            sizes,
+            filter,
+            tree.roots(),
+            window_start,
+            window_count,
         );
-        self.rebuild_filtered_visible(tree);
+
+        if self.is_searching() {
+            self.search.apply_materialization(result);
+        } else {
+            self.normal.apply_materialization(result);
+        }
     }
 
-    /// Rebuilds the visible slice for the active search result while preserving the main cache.
-    fn rebuild_filtered_visible(&mut self, tree: &DependencyTree) {
-        self.search_visible_cache.clear();
-        self.search_visible_last_non_group_child.fill(None);
+    /// Rebuilds the search view after applying new search state.
+    fn rebuild_search_view(&mut self, tree: &DependencyTree) {
         if self.search_match_ids.is_empty() {
+            self.search.clear();
             return;
         }
 
-        self.search_visible_cache.extend(
-            self.visible_cache
-                .iter()
-                .copied()
-                .filter(|node| self.search_visible_nodes[node.id.0]),
-        );
-        Self::populate_last_non_group_child_map(
-            tree,
-            &self.search_visible_cache,
-            &mut self.search_visible_last_non_group_child,
-        );
+        self.search
+            .recompute_subtree_sizes(tree, &self.open, Some(&self.search_visible_nodes));
+
+        // Clamp selection to search view bounds.
+        if let Some(vpos) = self.selected_virtual_pos
+            && vpos.0 >= self.search.total_virtual_lines
+            && self.search.total_virtual_lines > 0
+        {
+            self.selected_virtual_pos = Some(VirtualPos(self.search.total_virtual_lines - 1));
+        }
+
+        self.subtree_dirty = false;
+        self.dirty = true;
+        self.ensure_visible_nodes(tree);
     }
 
     /// Marks a matching node and all of its visible ancestors in the search bitset.
     ///
-    /// `search_visible_ids` tracks which bits were flipped so clearing or replacing search
-    /// state only touches previously marked nodes rather than resetting the whole vector.
+    /// A deduplicated node can have multiple parents, so this walks the full
+    /// parent DAG rather than a single ancestor chain.
     fn include_ancestors(
         tree: &DependencyTree,
         id: NodeId,
         search_visible_nodes: &mut [bool],
         search_visible_ids: &mut Vec<NodeId>,
     ) {
-        let mut current = Some(id);
-        while let Some(node_id) = current {
+        let mut stack = vec![id];
+        while let Some(node_id) = stack.pop() {
             if search_visible_nodes[node_id.0] {
-                break;
+                continue;
             }
 
             search_visible_nodes[node_id.0] = true;
             search_visible_ids.push(node_id);
 
-            current = tree.node(node_id).and_then(|node| node.parent());
+            stack.extend_from_slice(&tree.parents[node_id.0]);
         }
     }
 
-    fn collect_visible(
-        open: &[bool],
-        tree: &DependencyTree,
-        id: NodeId,
-        depth: usize,
-        out: &mut Vec<VisibleNode>,
-    ) {
-        out.push(VisibleNode { id, depth });
+    /// Ensures the selection points to a valid visible node, defaulting to position 0.
+    ///
+    /// Returns `true` if a valid selection exists after the operation.
+    fn ensure_selection(&mut self, tree: &DependencyTree) -> bool {
+        self.ensure_subtree_sizes(tree);
+        let total = self.active_total_virtual_lines();
 
-        if !open[id.0] {
-            return;
+        if total == 0 {
+            self.selected_virtual_pos = None;
+            return false;
         }
 
-        if let Some(node) = tree.node(id) {
-            for &child in node.children() {
-                Self::collect_visible(open, tree, child, depth + 1, out);
+        match self.selected_virtual_pos {
+            Some(vpos) if vpos.0 < total => true,
+            Some(_) => {
+                self.selected_virtual_pos = Some(VirtualPos(total - 1));
+                self.dirty = true;
+                true
+            }
+            None => {
+                self.selected_virtual_pos = Some(VirtualPos(0));
+                self.dirty = true;
+                true
             }
         }
     }
 
-    /// Ensures the selection points to a valid visible node, defaulting to the first entry.
-    ///
-    /// Returns `true` if a valid selection exists after the operation.
-    fn ensure_selection(&mut self, tree: &DependencyTree) -> bool {
-        let selected = self.selected;
-        self.ensure_visible_nodes(tree);
-        let visible = self.active_visible_nodes();
-
-        if visible.is_empty() {
-            self.selected = None;
-            return false;
-        }
-
-        if let Some(selected) = selected
-            && visible.iter().any(|node| node.id == selected)
-        {
-            return true;
-        }
-
-        self.selected = Some(visible[0].id);
-        true
-    }
-
-    /// Returns the index of the selected node among visible nodes.
-    pub fn selected_position(&mut self, tree: &DependencyTree) -> Option<usize> {
+    /// Returns the VisIdx of the selected node within the materialized cache.
+    pub fn selected_position(&mut self, tree: &DependencyTree) -> Option<VisIdx> {
         if !self.ensure_selection(tree) {
             return None;
         }
-
-        let selected = self.selected?;
-        let visible = self.active_visible_nodes();
-        Self::selected_index(visible, selected)
+        self.ensure_visible_nodes(tree);
+        self.selected_vis_idx()
     }
 
-    /// Helper to find the index of the selected node in the visible list.
-    fn selected_index(visible: &[VisibleNode], target: NodeId) -> Option<usize> {
-        visible.iter().position(|node| node.id == target)
+    /// Returns the cached selection VisIdx without triggering a rebuild.
+    pub fn selected_position_cached(&self) -> Option<VisIdx> {
+        self.selected_vis_idx()
+    }
+
+    /// Finds the VisIdx of the selected virtual position in the active cache.
+    fn selected_vis_idx(&self) -> Option<VisIdx> {
+        let vpos = self.selected_virtual_pos?;
+        self.find_by_vpos(vpos).map(|(idx, _)| idx)
+    }
+
+    /// Returns the total virtual line count for scrollbar/viewport calculations.
+    pub fn total_lines(&mut self, tree: &DependencyTree) -> usize {
+        self.ensure_subtree_sizes(tree);
+        self.active_total_virtual_lines()
+    }
+
+    /// Returns the selected virtual position.
+    pub fn selected_virtual_pos(&self) -> Option<VirtualPos> {
+        self.selected_virtual_pos
     }
 
     /// Updates the available viewport.
+    ///
+    /// If the new viewport height exceeds the previous one, the materialized
+    /// window (sized at `height * 2`) no longer covers the visible area, so
+    /// rematerialization is forced.
     pub(crate) fn update_viewport(&mut self, viewport: Viewport) {
+        if viewport.height > self.viewport.height {
+            self.dirty = true;
+        }
         self.viewport = viewport;
     }
 
@@ -671,33 +726,65 @@ impl TreeWidgetState {
                 }
             }
         }
+        self.subtree_dirty = true;
         self.dirty = true;
         self.ensure_selection(tree);
     }
+}
 
-    /// Records, for each parent in the active visible slice, the last visible non-group child.
-    ///
-    /// The render path uses this cache to decide whether a node should draw a continuing
-    /// branch (`├──`) or a terminating branch (`└──`) without rescanning siblings.
-    /// Group nodes are skipped because they are labels and do not keep branch guides alive.
-    fn populate_last_non_group_child_map(
-        tree: &DependencyTree,
-        visible_nodes: &[VisibleNode],
-        target: &mut [Option<NodeId>],
-    ) {
-        target.fill(None);
-        for node in visible_nodes {
-            let Some(tree_node) = tree.node(node.id) else {
-                continue;
-            };
+/// Finds the virtual position of the first occurrence of a `NodeId` in the virtual tree.
+fn find_virtual_pos(
+    tree: &DependencyTree,
+    open: &[bool],
+    sizes: &[usize],
+    filter: Option<&[bool]>,
+    roots: &[NodeId],
+    target: NodeId,
+) -> Option<VirtualPos> {
+    let mut vpos = 0usize;
+    for &root in roots {
+        if filter.is_some_and(|f| !f[root.0]) {
+            continue;
+        }
+        if let Some(found) = find_vpos_recursive(tree, open, sizes, filter, root, target, &mut vpos)
+        {
+            return Some(VirtualPos(found));
+        }
+    }
+    None
+}
 
-            if tree_node.is_group() {
+fn find_vpos_recursive(
+    tree: &DependencyTree,
+    open: &[bool],
+    sizes: &[usize],
+    filter: Option<&[bool]>,
+    id: NodeId,
+    target: NodeId,
+    vpos: &mut usize,
+) -> Option<usize> {
+    if id == target {
+        return Some(*vpos);
+    }
+
+    *vpos += 1;
+
+    if open[id.0]
+        && let Some(node) = tree.node(id)
+    {
+        for &child in node.children() {
+            if filter.is_some_and(|f| !f[child.0]) {
                 continue;
             }
-
-            if let Some(parent_id) = tree_node.parent() {
-                target[parent_id.0] = Some(node.id);
+            if child != target && sizes[child.0] == 0 {
+                continue;
+            }
+            if let Some(found) = find_vpos_recursive(tree, open, sizes, filter, child, target, vpos)
+            {
+                return Some(found);
             }
         }
     }
+
+    None
 }

--- a/src/ops/tree/tui/widget/view_cache.rs
+++ b/src/ops/tree/tui/widget/view_cache.rs
@@ -1,40 +1,101 @@
+use std::ops::Range;
+
 use crate::core::{DependencyTree, NodeId};
 
 use super::state::{VirtualPos, VisIdx, VisibleNode};
 
-/// Cached materialization state for a single view (normal or search-filtered).
+/// Cached render state for a single view of the dependency tree.
+///
+/// The widget maintains two [`ViewCache`]s in parallel: one for the normal view
+/// and one for the search-filtered view, so toggling search doesn't require
+/// re-materializing from scratch.
+///
+/// Conceptually, the cache straddles two coordinate spaces.
+///
+/// `subtree_sizes` and `total_virtual_lines` describe the *full virtual
+/// stream*: every row that would exist if the tree were flattened end-to-end,
+/// indexed by `NodeId`.
+///
+/// Computing them is the slow pass, but it only re-runs when expansion or
+/// filter state changes.
+///
+/// `nodes` describes the *small materialized window* around the viewport,
+/// plus the ancestor chain needed for breadcrumbs and indentation, indexed by
+/// `VisIdx`.
+///
+/// That window is cheap to rebuild and is refilled on every scroll, because
+/// [`materialize_window`] uses the precomputed sizes to skip whole subtrees in
+/// O(1) and emit only the rows actually on screen.
+///
+/// # Example
+///
+/// For a tree like:
+///
+/// root
+/// |- a
+/// |  `- c
+/// `- b
+///
+/// the full virtual stream is:
+///
+///   0: root
+///   1: a
+///   2: c
+///   3: b
+///
+/// If the viewport wants rows `[1, 3)`, `nodes` only stores the small
+/// materialized slice:
+///
+///   0: root  (ancestor prefix kept for context)
+///   1: a
+///   2: c
+///
+/// So `total_virtual_lines` is `4`, while `nodes.len()` is only `3`.
+///
+/// This is the optimization: keep the full stream virtual, precompute subtree
+/// sizes once, and rebuild only the small materialized slice needed for the
+/// current viewport.
 #[derive(Debug, Default)]
 pub(super) struct ViewCache {
-    /// Materialized window of visible nodes around the viewport.
-    pub(super) nodes: Vec<VisibleNode>,
-    /// Last visible non-group child per parent, indexed by parent visible index.
-    pub(super) last_non_group_child: Vec<Option<VisIdx>>,
-    /// Memoized visible-subtree sizes indexed by NodeId.
+    /// Materialized slice of visible nodes covering the current viewport plus
+    /// the ancestor prefix needed for lineage rendering.
+    pub(super) nodes: Vec<VisibleNode>, // indexed by VisIdx
+
+    /// `NodeId`-indexed memoization of visible-subtree sizes.
+    ///
+    /// Enables O(1) "skip this whole subtree" checks during materialization.
+    ///
+    /// Example:
+    ///
+    /// root
+    /// |- a
+    /// |  `- many hundreds of rows...
+    /// `- b
+    ///
+    /// If `subtree_sizes[a] = 500` and the viewport starts after those 500
+    /// rows, the widget does not need to walk all of `a`'s descendants. It can
+    /// skip the entire subtree in O(1) and continue from `b`.
     pub(super) subtree_sizes: Vec<usize>,
-    /// Total number of virtual lines (sum of root subtree sizes).
+
+    /// Total visible line count across all roots.
+    ///
+    /// This equals the height of the fully-flattened virtual stream. Used as the scrollbar extent.
     pub(super) total_virtual_lines: usize,
-    /// Whether sibling links / last-child map need recomputation.
-    pub(super) metadata_dirty: bool,
 }
 
 impl ViewCache {
     /// Clears all cached data, resetting to empty state.
     pub(super) fn clear(&mut self) {
         self.nodes.clear();
-        self.last_non_group_child.fill(None);
         self.subtree_sizes.clear();
         self.total_virtual_lines = 0;
-        self.metadata_dirty = false;
-    }
-
-    /// Applies a materialization result to this cache.
-    pub(super) fn apply_materialization(&mut self, result: MaterializeResult) {
-        self.nodes = result.nodes;
-        self.metadata_dirty = true;
     }
 
     /// Recomputes subtree sizes for the given filter.
-    pub(super) fn recompute_subtree_sizes(
+    ///
+    /// Must be called whenever `open` or `filter` changes; pure scrolls can skip
+    /// straight to [`ViewCache::rematerialize`].
+    pub(super) fn refresh_sizes(
         &mut self,
         tree: &DependencyTree,
         open: &[bool],
@@ -44,132 +105,133 @@ impl ViewCache {
             compute_subtree_sizes(tree, open, filter, &mut self.subtree_sizes);
     }
 
-    /// Ensures sibling links and last-child map are up to date.
-    pub(super) fn ensure_metadata(&mut self, tree: &DependencyTree) {
-        if !self.metadata_dirty || self.nodes.is_empty() {
-            return;
-        }
-        Self::populate_sibling_links(&mut self.nodes);
-        Self::populate_last_non_group_child_map(tree, &self.nodes, &mut self.last_non_group_child);
-        self.metadata_dirty = false;
-    }
-
-    /// Records, for each parent visible position, the last visible non-group child position.
-    fn populate_last_non_group_child_map(
+    /// Refills the materialized window using the cache's existing `subtree_sizes`.
+    ///
+    /// The caller must have invoked [`ViewCache::refresh_sizes`] with the same
+    /// `open`/`filter` since the last mutation to either, or the emitted rows
+    /// will not match the current view.
+    pub(super) fn rematerialize(
+        &mut self,
         tree: &DependencyTree,
-        visible_nodes: &[VisibleNode],
-        target: &mut Vec<Option<VisIdx>>,
+        open: &[bool],
+        filter: Option<&[bool]>,
+        roots: &[NodeId],
+        window: Range<usize>,
     ) {
-        target.clear();
-        target.resize(visible_nodes.len(), None);
-
-        for (vis_idx, node) in visible_nodes.iter().enumerate() {
-            let Some(tree_node) = tree.node(node.id) else {
-                continue;
-            };
-
-            if tree_node.is_group() {
-                continue;
-            }
-
-            if let Some(parent_vis_idx) = node.parent_vis_idx {
-                target[parent_vis_idx.0] = Some(VisIdx(vis_idx));
-            }
-        }
-    }
-
-    /// Links each visible node to its next and previous sibling (same parent).
-    fn populate_sibling_links(visible_nodes: &mut [VisibleNode]) {
-        let mut last_child_of: Vec<Option<VisIdx>> = vec![None; visible_nodes.len()];
-
-        for i in 0..visible_nodes.len() {
-            let Some(parent) = visible_nodes[i].parent_vis_idx else {
-                continue;
-            };
-
-            let current = VisIdx(i);
-            if let Some(prev) = last_child_of[parent.0] {
-                visible_nodes[prev.0].next_sibling = Some(current);
-                visible_nodes[i].prev_sibling = Some(prev);
-            }
-            last_child_of[parent.0] = Some(current);
-        }
+        self.nodes = materialize_window(tree, open, &self.subtree_sizes, filter, roots, window);
     }
 }
 
-// ── Materialization ─────────────────────────────────────────────────
-
-/// Output of windowed materialization.
-pub(super) struct MaterializeResult {
-    /// Materialized nodes: ancestor prefix + viewport window.
-    pub(super) nodes: Vec<VisibleNode>,
+/// One frame on the DFS ancestor stack inside [`MaterializeCtx`].
+///
+/// We keep ancestors on a stack (rather than re-walking the tree) because every
+/// emitted node needs three things from its parent that the raw [`DependencyTree`]
+/// doesn't carry: the parent's [`VisIdx`] in the output buffer, the most recently
+/// emitted sibling (for `prev/next_sibling` wiring), and the parent's depth.
+///
+/// `output_idx` is `None` while the DFS is still above the viewport — in that
+/// case the ancestor hasn't been emitted yet. It's filled in either when the
+/// node itself enters the window, or when [`MaterializeCtx::emit_ancestor_prefix`]
+/// flushes the whole ancestor chain on the first in-window emission.
+struct Ancestor {
+    id: NodeId,
+    depth: usize,
+    virtual_pos: usize,
+    /// Index into `MaterializeCtx::output` once this ancestor has been emitted
+    /// (either as part of the prefix or as a normal window node). `None` until
+    /// then. Used by children to set their `parent_vis_idx` in O(1).
+    output_idx: Option<usize>,
+    /// Output index of the most recently emitted child of this ancestor.
+    ///
+    /// Lets the next emitted child wire `prev_sibling` and back-patch the
+    /// previous child's `next_sibling` without scanning `output`.
+    last_child_output_idx: Option<usize>,
+    /// `NodeId` of this ancestor's last non-group child that passes the filter,
+    /// computed once at push time from the *full* child list (not just the
+    /// in-window subset). A child compares its own `id` against this to set
+    /// its `is_last_non_group_child` flag, so prefix-emitted ancestors and
+    /// in-window nodes whose later siblings fall past `window.end` still
+    /// render the correct `└─` vs `├─` connector.
+    last_non_group_child_id: Option<NodeId>,
 }
 
+/// Mutable working state for one [`materialize_window`] call.
+///
+/// Bundling everything into a struct keeps the recursive helpers
+/// ([`materialize_node`], [`emit_node`], [`emit_ancestor_prefix`]) cheap to
+/// call. They take `&mut self` instead of a long parameter list, and the
+/// shared cycle guard / ancestor stack stay live across the whole DFS.
+///
+/// [`materialize_node`]: MaterializeCtx::materialize_node
+/// [`emit_node`]: MaterializeCtx::emit_node
+/// [`emit_ancestor_prefix`]: MaterializeCtx::emit_ancestor_prefix
 struct MaterializeCtx<'a> {
     tree: &'a DependencyTree,
+    /// Per-`NodeId` expansion state. Closed nodes don't recurse into children and fill one row.
     open: &'a [bool],
+    /// Memoized subtree sizes from [`compute_subtree_sizes`]. Lets the DFS
+    /// skip entire subtrees that fall before the window in O(1).
     sizes: &'a [usize],
+    /// Optional `NodeId` mask for the search-filtered view. `None` means no filter.
     filter: Option<&'a [bool]>,
+    /// Running position in the fully-flattened virtual line stream. Advances
+    /// once per node visited (or jumps by `subtree_size` when skipping).
     virtual_pos: usize,
-    window_start: usize,
-    window_end: usize,
-    /// Stack of ancestors on the current DFS path: (NodeId, depth, virtual_pos).
-    ancestor_stack: Vec<(NodeId, usize, usize)>,
-    /// Cycle guard: nodes currently on the DFS path. Mirrors `in_progress`
-    /// in `compute_size_recursive` so back-edges in cyclic dep graphs
-    /// (e.g. dev-dep cycles) are emitted as leaves rather than recursed into.
+    /// Viewport window in virtual-line space (half-open: start inclusive, end exclusive).
+    window: Range<usize>,
+    /// Stack of ancestors on the current DFS path, deepest at the back.
+    /// Drives parent / sibling resolution for emitted nodes.
+    ancestor_stack: Vec<Ancestor>,
+    /// Cycle guard: `true` for nodes currently on the DFS path. Mirrors
+    /// `in_progress` in [`compute_size_recursive`] so back-edges in cyclic
+    /// dep graphs (e.g. dev-dep cycles) are emitted as leaves rather than
+    /// recursed into. The two passes MUST agree on which edges are leaves,
+    /// otherwise sizes and emitted-node counts diverge.
     in_progress: Vec<bool>,
-    prefix_emitted: bool,
+    /// Emitted nodes, in DFS order. Returned from [`materialize_window`].
     output: Vec<VisibleNode>,
 }
 
 impl MaterializeCtx<'_> {
+    /// Walk one subtree in DFS order and emit rows only if that subtree
+    /// overlaps the current viewport window.
+    ///
+    /// `subtree_sizes` lets this fast-path whole branches that fall entirely
+    /// before the window, while `ancestor_stack` carries the parent/sibling
+    /// context needed when a row is actually emitted.
     fn materialize_node(&mut self, id: NodeId, depth: usize, parent_ancestor_idx: Option<usize>) {
-        let my_vpos = self.virtual_pos;
+        // Filtered-out nodes don't exist in the virtual stream — don't advance.
+        if self.filter.is_some_and(|f| !f[id.0]) {
+            return;
+        }
+
+        let current_vpos = self.virtual_pos;
         let subtree_size = self.sizes[id.0];
 
         // Entirely before window — skip subtree
-        if my_vpos + subtree_size <= self.window_start {
+        if current_vpos + subtree_size <= self.window.start {
             self.virtual_pos += subtree_size;
             return;
         }
 
         // Entirely past window — stop
-        if my_vpos >= self.window_end {
+        if current_vpos >= self.window.end {
             return;
         }
 
         // This node is in or overlaps the window.
         self.virtual_pos += 1;
 
-        let in_window = my_vpos >= self.window_start;
-
+        let in_window = current_vpos >= self.window.start;
         if in_window {
-            // Emit ancestor prefix if this is the first in-window node.
-            if !self.prefix_emitted {
+            // Flush the ancestor prefix on the first in-window emission.
+            if self.output.is_empty() {
                 self.emit_ancestor_prefix();
             }
-
-            let parent_vis_idx = if depth == 0 {
-                None
-            } else {
-                // Find the parent in the output buffer.
-                // The parent is the last ancestor_stack entry, which was either emitted
-                // as prefix or as a previous window node.
-                self.find_parent_vis_idx(parent_ancestor_idx)
-            };
-
-            self.output.push(VisibleNode {
-                id,
-                depth,
-                virtual_pos: VirtualPos(my_vpos),
-                parent_vis_idx,
-                next_sibling: None,
-                prev_sibling: None,
-            });
+            self.emit_node(id, depth, current_vpos, parent_ancestor_idx);
         }
 
-        // Recurse into children if open. Skip recursion on a back-edge —
+        // Recurse into children if open. Skip recursion on a back-edge;
         // a node already on the current DFS path is a cycle, and the size
         // accounting in `compute_size_recursive` treats it as a leaf.
         if self.open[id.0]
@@ -177,20 +239,27 @@ impl MaterializeCtx<'_> {
             && let Some(node) = self.tree.node(id)
         {
             let my_ancestor_idx = self.ancestor_stack.len();
-            self.ancestor_stack.push((id, depth, my_vpos));
+            // If this node was emitted, child sibling-linking will resolve
+            // its output_idx via `ancestor_stack[my_ancestor_idx].output_idx`.
+            let output_idx = if in_window {
+                Some(self.output.len() - 1)
+            } else {
+                None
+            };
+            let last_non_group_child_id = self.last_non_group_child_of(node);
+            self.ancestor_stack.push(Ancestor {
+                id,
+                depth,
+                virtual_pos: current_vpos,
+                output_idx,
+                last_child_output_idx: None,
+                last_non_group_child_id,
+            });
             self.in_progress[id.0] = true;
 
             for &child in node.children() {
-                if self.filter.is_some_and(|f| !f[child.0]) {
-                    continue;
-                }
-                if self.virtual_pos >= self.window_end {
+                if self.virtual_pos >= self.window.end {
                     break;
-                }
-                let child_size = self.sizes[child.0];
-                if self.virtual_pos + child_size <= self.window_start {
-                    self.virtual_pos += child_size;
-                    continue;
                 }
                 self.materialize_node(child, depth + 1, Some(my_ancestor_idx));
             }
@@ -200,103 +269,152 @@ impl MaterializeCtx<'_> {
         }
     }
 
-    /// Emits ancestor prefix nodes for lineage/breadcrumb rendering.
-    fn emit_ancestor_prefix(&mut self) {
-        self.prefix_emitted = true;
+    /// Pushes a node into `output` and wires up parent / sibling metadata.
+    fn emit_node(
+        &mut self,
+        id: NodeId,
+        depth: usize,
+        my_vpos: usize,
+        parent_ancestor_idx: Option<usize>,
+    ) {
+        let my_output_idx = self.output.len();
+        let my_vis_idx = VisIdx(my_output_idx);
 
-        if self.ancestor_stack.is_empty() {
-            return;
+        // Resolve parent + wire sibling links from the parent's last child.
+        let (parent_vis_idx, prev_sibling, is_last_non_group_child) = match parent_ancestor_idx {
+            Some(idx) => {
+                let parent = &mut self.ancestor_stack[idx];
+                let parent_output_idx = parent
+                    .output_idx
+                    .expect("parent ancestor must be emitted before its in-window child");
+                let prev = parent.last_child_output_idx.map(VisIdx);
+                parent.last_child_output_idx = Some(my_output_idx);
+                let is_last = parent.last_non_group_child_id == Some(id);
+                (Some(VisIdx(parent_output_idx)), prev, is_last)
+            }
+            None => (None, None, true),
+        };
+
+        if let Some(prev) = prev_sibling {
+            self.output[prev.0].next_sibling = Some(my_vis_idx);
         }
 
-        for i in 0..self.ancestor_stack.len() {
-            let (anc_id, anc_depth, anc_vpos) = self.ancestor_stack[i];
+        self.output.push(VisibleNode {
+            id,
+            depth,
+            virtual_pos: VirtualPos(my_vpos),
+            parent_vis_idx,
+            next_sibling: None,
+            prev_sibling,
+            is_last_non_group_child,
+        });
+    }
 
-            let parent_vis_idx = if anc_depth == 0 || i == 0 {
-                None
+    /// Returns the `NodeId` of `parent`'s last non-group child that passes the
+    /// filter, or `None` if it has no such child. Walks the full child list
+    /// (not just the in-window subset), so the result is stable across
+    /// scrolling and reflects the true visible tree.
+    fn last_non_group_child_of(&self, parent: &crate::core::DependencyNode) -> Option<NodeId> {
+        parent.children().iter().rev().copied().find(|&c| {
+            self.filter.is_none_or(|f| f[c.0]) && self.tree.node(c).is_some_and(|n| !n.is_group())
+        })
+    }
+
+    /// Emits ancestor prefix nodes for lineage/breadcrumb rendering. The prefix
+    /// is a single chain (each ancestor is the only emitted child of the one
+    /// above it), so sibling links stay None and parent links walk the chain.
+    fn emit_ancestor_prefix(&mut self) {
+        for i in 0..self.ancestor_stack.len() {
+            let ancestor = &self.ancestor_stack[i];
+            let id = ancestor.id;
+            let depth = ancestor.depth;
+            let vpos = ancestor.virtual_pos;
+
+            let (parent_vis_idx, is_last_non_group_child) = if i == 0 {
+                (None, true)
             } else {
-                // Parent is the previous ancestor in the prefix.
-                Some(VisIdx(self.output.len() - 1))
+                let parent = &self.ancestor_stack[i - 1];
+                (
+                    parent.output_idx.map(VisIdx),
+                    parent.last_non_group_child_id == Some(id),
+                )
             };
 
+            let my_output_idx = self.output.len();
             self.output.push(VisibleNode {
-                id: anc_id,
-                depth: anc_depth,
-                virtual_pos: VirtualPos(anc_vpos),
+                id,
+                depth,
+                virtual_pos: VirtualPos(vpos),
                 parent_vis_idx,
                 next_sibling: None,
                 prev_sibling: None,
+                is_last_non_group_child,
             });
+            self.ancestor_stack[i].output_idx = Some(my_output_idx);
+            self.ancestor_stack[i].last_child_output_idx = None;
+            if i > 0 {
+                self.ancestor_stack[i - 1].last_child_output_idx = Some(my_output_idx);
+            }
         }
-    }
-
-    /// Finds the VisIdx of the parent node in the output buffer.
-    fn find_parent_vis_idx(&self, parent_ancestor_idx: Option<usize>) -> Option<VisIdx> {
-        let parent_ancestor_idx = parent_ancestor_idx?;
-        let (parent_id, _, parent_vpos) = self.ancestor_stack[parent_ancestor_idx];
-
-        // Search the output buffer for this parent.
-        // It's either in the prefix or was emitted as a window node.
-        // Search from the end since the parent was recently emitted.
-        self.output
-            .iter()
-            .rposition(|n| n.id == parent_id && n.virtual_pos == VirtualPos(parent_vpos))
-            .map(VisIdx)
     }
 }
 
-/// Materializes a window of visible nodes around a viewport range.
+/// Build the small visible slice of the tree for the current viewport.
 ///
-/// The output contains an ancestor prefix (for lineage/breadcrumb rendering)
-/// followed by the viewport window nodes. Only nodes within `[window_start, window_end)`
-/// are emitted, plus ancestors of the first emitted node.
-pub(super) fn materialize_window(
+/// The result starts with any ancestor rows needed for context rendering, then
+/// contains the nodes whose virtual positions fall inside `window`.
+///
+/// Parent, sibling, and "last child" metadata are filled in as the rows are
+/// emitted, so the renderer can use the result directly.
+///
+/// # Parameters
+///
+/// - `tree`: the arena being walked. Read-only; only its node/children
+///   accessors are used.
+/// - `open`: per-`NodeId` expansion state. A closed node is emitted but its
+///   children are skipped.
+/// - `sizes`: precomputed visible-subtree sizes from [`compute_subtree_sizes`].
+///   Must have been built with the same `open` and `filter` as this call,
+///   otherwise the skip-subtree fast path emits the wrong rows. This is the
+///   table that makes the walk O(window) instead of O(tree).
+/// - `filter`: optional `NodeId` mask for the search-filtered view; `None`
+///   means no filter. Filtered-out nodes are treated as if they didn't exist
+///   (skipped without advancing `virtual_pos`).
+/// - `roots`: the top-level nodes to walk, in order. Typically `tree.roots()`.
+/// - `window`: viewport range in virtual-line coordinates (start inclusive,
+///   end exclusive; 0 = first line of the flattened tree).
+fn materialize_window(
     tree: &DependencyTree,
     open: &[bool],
     sizes: &[usize],
     filter: Option<&[bool]>,
     roots: &[NodeId],
-    window_start: usize,
-    window_count: usize,
-) -> MaterializeResult {
+    window: Range<usize>,
+) -> Vec<VisibleNode> {
+    let cap = window.len() + 64;
     let mut ctx = MaterializeCtx {
         tree,
         open,
         sizes,
         filter,
         virtual_pos: 0,
-        window_start,
-        window_end: window_start + window_count,
+        window,
         ancestor_stack: Vec::with_capacity(64),
         in_progress: vec![false; tree.nodes.len()],
-        prefix_emitted: false,
-        output: Vec::with_capacity(window_count + 64),
+        output: Vec::with_capacity(cap),
     };
 
     for &root in roots {
-        if filter.is_some_and(|f| !f[root.0]) {
-            continue;
-        }
-        if ctx.virtual_pos >= ctx.window_end {
+        if ctx.virtual_pos >= ctx.window.end {
             break;
-        }
-        let root_size = sizes[root.0];
-        if ctx.virtual_pos + root_size <= ctx.window_start {
-            ctx.virtual_pos += root_size;
-            continue;
         }
         ctx.materialize_node(root, 0, None);
     }
 
-    MaterializeResult { nodes: ctx.output }
+    ctx.output
 }
 
-// ── Subtree size computation ──��─────────────────────────────────────
-
 /// Computes memoized visible-subtree sizes for all nodes.
-///
-/// `subtree_size[id] = 1 + (if open[id]: Σ subtree_size[child])`.
-/// A `computed` guard prevents recomputing already-visited nodes (DAG memoization).
-/// An `in_progress` guard breaks hypothetical cycles by treating in-progress nodes as leaves.
 fn compute_subtree_sizes(
     tree: &DependencyTree,
     open: &[bool],
@@ -305,7 +423,10 @@ fn compute_subtree_sizes(
 ) -> usize {
     sizes.clear();
     sizes.resize(tree.nodes.len(), 0);
+    // prevents recomputing already-visited nodes
     let mut computed = vec![false; tree.nodes.len()];
+    // avoid infinite graphs by breaking hypothetical cycles;
+    // in-progress nodes are treated as leaves to avoid infinite recursion
     let mut in_progress = vec![false; tree.nodes.len()];
 
     let mut total = 0usize;
@@ -339,15 +460,18 @@ fn compute_size_recursive(
         return 1; // cycle break
     }
     if computed[id.0] {
+        // Shared subtree: reuse the size already computed from another parent.
         return sizes[id.0];
     }
 
     in_progress[id.0] = true;
 
+    // Every visible node contributes at least one row for itself.
     let mut size: usize = 1;
     if open[id.0]
         && let Some(node) = tree.node(id)
     {
+        // Open nodes contribute the sizes of all visible children.
         for &child in node.children() {
             if filter.is_some_and(|f| !f[child.0]) {
                 continue;
@@ -360,4 +484,375 @@ fn compute_size_recursive(
     computed[id.0] = true;
     in_progress[id.0] = false;
     size
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::{Dependency, DependencyNode, DependencyTree};
+
+    /// Builds an arena tree from a slice of `(name, children)` tuples.
+    /// Node ids are positional; the first entry is the sole root.
+    fn build(spec: &[(&str, &[usize])]) -> DependencyTree {
+        let nodes: Vec<DependencyNode> = spec
+            .iter()
+            .map(|(name, children)| {
+                DependencyNode::Crate(Dependency {
+                    name: String::from(*name),
+                    version: String::from("0.0.0"),
+                    manifest_dir: None,
+                    is_proc_macro: false,
+                    children: children.iter().copied().map(NodeId).collect(),
+                })
+            })
+            .collect();
+
+        let mut parents: Vec<Vec<NodeId>> = vec![Vec::new(); nodes.len()];
+        for (idx, node) in nodes.iter().enumerate() {
+            for &child in node.children() {
+                parents[child.0].push(NodeId(idx));
+            }
+        }
+
+        DependencyTree {
+            workspace_name: String::from("test"),
+            nodes,
+            parents,
+            roots: vec![NodeId(0)],
+        }
+    }
+
+    /// Standard 6-node fixture:
+    /// ```text
+    /// root            (id 0)
+    /// ├── a           (id 1)
+    /// │   ├── aa      (id 2)
+    /// │   └── ab      (id 3)
+    /// └── b           (id 4)
+    ///     └── bb      (id 5)
+    /// ```
+    /// Virtual positions when fully open: root=0, a=1, aa=2, ab=3, b=4, bb=5.
+    fn fixture() -> DependencyTree {
+        build(&[
+            ("root", &[1, 4]),
+            ("a", &[2, 3]),
+            ("aa", &[]),
+            ("ab", &[]),
+            ("b", &[5]),
+            ("bb", &[]),
+        ])
+    }
+
+    fn all_open(tree: &DependencyTree) -> Vec<bool> {
+        vec![true; tree.nodes.len()]
+    }
+
+    fn materialize(
+        tree: &DependencyTree,
+        open: &[bool],
+        start: usize,
+        count: usize,
+    ) -> (Vec<usize>, Vec<VisibleNode>) {
+        let mut cache = ViewCache::default();
+        cache.refresh_sizes(tree, open, None);
+        cache.rematerialize(tree, open, None, tree.roots(), start..start + count);
+        let root_sum: usize = tree.roots().iter().map(|r| cache.subtree_sizes[r.0]).sum();
+        assert_eq!(cache.total_virtual_lines, root_sum);
+        (cache.subtree_sizes, cache.nodes)
+    }
+
+    #[test]
+    fn subtree_sizes_all_open() {
+        let tree = fixture();
+        let mut sizes = Vec::new();
+        let total = compute_subtree_sizes(&tree, &all_open(&tree), None, &mut sizes);
+        assert_eq!(sizes, vec![6, 3, 1, 1, 2, 1]);
+        assert_eq!(total, 6);
+    }
+
+    #[test]
+    fn subtree_sizes_with_closed_node() {
+        let tree = fixture();
+        let mut open = all_open(&tree);
+        open[1] = false;
+        // close `a`:
+        //
+        // root
+        // |- a
+        // `- b
+        //    `- bb
+        let mut sizes = Vec::new();
+        let total = compute_subtree_sizes(&tree, &open, None, &mut sizes);
+        assert_eq!(sizes[1], 1);
+        assert_eq!(sizes[0], 4); // root, a, b, bb
+        assert_eq!(total, 4);
+    }
+
+    #[test]
+    fn subtree_sizes_breaks_cycle() {
+        // cycle:
+        //
+        // root
+        // `- a
+        //    `- b
+        //       `- a   (back-edge, counted as a leaf)
+        let tree = build(&[("root", &[1]), ("a", &[2]), ("b", &[1])]);
+        let mut sizes = Vec::new();
+        let total = compute_subtree_sizes(&tree, &all_open(&tree), None, &mut sizes);
+        // sizes:
+        //
+        // a(back-edge leaf) = 1
+        // b                = 1 + 1 = 2
+        // a                = 1 + 2 = 3
+        // root             = 1 + 3 = 4
+        assert_eq!(sizes[0], 4);
+        assert_eq!(total, 4);
+    }
+
+    #[test]
+    fn subtree_sizes_with_filter() {
+        let tree = fixture();
+        // filter out `a` and its descendants:
+        //
+        // root
+        // `- b
+        //    `- bb
+        let filter = vec![true, false, false, false, true, true];
+        let mut sizes = Vec::new();
+        let total = compute_subtree_sizes(&tree, &all_open(&tree), Some(&filter), &mut sizes);
+        // root keeps only the `b` subtree: 1 + 2 = 3
+        assert_eq!(sizes[0], 3);
+        assert_eq!(total, 3);
+    }
+
+    #[test]
+    fn materialize_full_tree() {
+        let tree = fixture();
+        let (_, nodes) = materialize(&tree, &all_open(&tree), 0, 6);
+        assert_eq!(nodes.len(), 6);
+        let ids: Vec<usize> = nodes.iter().map(|n| n.id.0).collect();
+        assert_eq!(ids, vec![0, 1, 2, 3, 4, 5]);
+        let depths: Vec<usize> = nodes.iter().map(|n| n.depth).collect();
+        assert_eq!(depths, vec![0, 1, 2, 2, 1, 2]);
+        let vpos: Vec<usize> = nodes.iter().map(|n| n.virtual_pos.0).collect();
+        assert_eq!(vpos, vec![0, 1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn materialize_window_in_middle_emits_ancestor_prefix() {
+        let tree = fixture();
+        // full tree:
+        //
+        // root
+        // |- a
+        // |  |- aa
+        // |  `- ab
+        // `- b
+        //    `- bb
+        //
+        // window [3, 5):
+        //
+        // ab
+        // b
+        let (_, nodes) = materialize(&tree, &all_open(&tree), 3, 2);
+        // emitted rows:
+        //
+        // root
+        // `- a
+        //    `- ab
+        // b
+        let ids: Vec<usize> = nodes.iter().map(|n| n.id.0).collect();
+        assert_eq!(ids, vec![0, 1, 3, 4]);
+        let depths: Vec<usize> = nodes.iter().map(|n| n.depth).collect();
+        assert_eq!(depths, vec![0, 1, 2, 1]);
+
+        // ab's parent is `a` at vis idx 1; b's parent is root at vis idx 0.
+        assert_eq!(nodes[2].parent_vis_idx, Some(VisIdx(1)));
+        assert_eq!(nodes[3].parent_vis_idx, Some(VisIdx(0)));
+        assert_eq!(nodes[0].parent_vis_idx, None);
+    }
+
+    #[test]
+    fn materialize_window_at_deepest_node_emits_full_prefix() {
+        let tree = fixture();
+        // full tree:
+        //
+        // root
+        // |- a
+        // |  |- aa
+        // |  `- ab
+        // `- b
+        //    `- bb
+        //
+        // window [5, 6):
+        //
+        // bb
+        let (_, nodes) = materialize(&tree, &all_open(&tree), 5, 1);
+        // emitted rows:
+        //
+        // root
+        // `- b
+        //    `- bb
+        let ids: Vec<usize> = nodes.iter().map(|n| n.id.0).collect();
+        assert_eq!(ids, vec![0, 4, 5]);
+        let depths: Vec<usize> = nodes.iter().map(|n| n.depth).collect();
+        assert_eq!(depths, vec![0, 1, 2]);
+        assert_eq!(nodes[0].parent_vis_idx, None);
+        assert_eq!(nodes[1].parent_vis_idx, Some(VisIdx(0)));
+        assert_eq!(nodes[2].parent_vis_idx, Some(VisIdx(1)));
+    }
+
+    #[test]
+    fn materialize_window_past_end_is_empty() {
+        let tree = fixture();
+        let (_, nodes) = materialize(&tree, &all_open(&tree), 100, 10);
+        assert!(nodes.is_empty());
+    }
+
+    #[test]
+    fn materialize_window_larger_than_tree() {
+        let tree = fixture();
+        let (_, nodes) = materialize(&tree, &all_open(&tree), 0, 1000);
+        assert_eq!(nodes.len(), 6);
+    }
+
+    #[test]
+    fn materialize_with_closed_node_skips_subtree() {
+        let tree = fixture();
+        let mut open = all_open(&tree);
+        open[1] = false;
+        // close `a`:
+        //
+        // root
+        // |- a
+        // `- b
+        //    `- bb
+        let (_, nodes) = materialize(&tree, &open, 0, 10);
+        let ids: Vec<usize> = nodes.iter().map(|n| n.id.0).collect();
+        assert_eq!(ids, vec![0, 1, 4, 5]);
+        let vpos: Vec<usize> = nodes.iter().map(|n| n.virtual_pos.0).collect();
+        assert_eq!(vpos, vec![0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn materialize_with_cycle_treats_back_edge_as_leaf() {
+        // cycle:
+        //
+        // root
+        // `- a
+        //    `- b
+        //       `- a   (back-edge)
+        //
+        // The back-edge node is emitted as a leaf at the deeper depth, but its
+        // children are not recursed into. This matches `compute_subtree_sizes`,
+        // which also counts the back-edge as 1.
+        let tree = build(&[("root", &[1]), ("a", &[2]), ("b", &[1])]);
+        let (sizes, nodes) = materialize(&tree, &all_open(&tree), 0, 100);
+        assert_eq!(nodes.len(), sizes[0]); // size/materialization parity
+        let ids: Vec<usize> = nodes.iter().map(|n| n.id.0).collect();
+        assert_eq!(ids, vec![0, 1, 2, 1]); // root, a, b, a(back-edge leaf)
+        let depths: Vec<usize> = nodes.iter().map(|n| n.depth).collect();
+        assert_eq!(depths, vec![0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn materialize_with_filter_excludes_subtree() {
+        let tree = fixture();
+        let filter = vec![true, false, false, false, true, true];
+        let mut cache = ViewCache::default();
+        cache.refresh_sizes(&tree, &all_open(&tree), Some(&filter));
+        cache.rematerialize(&tree, &all_open(&tree), Some(&filter), tree.roots(), 0..10);
+        let ids: Vec<usize> = cache.nodes.iter().map(|n| n.id.0).collect();
+        assert_eq!(ids, vec![0, 4, 5]);
+    }
+
+    fn build_cache(tree: &DependencyTree) -> ViewCache {
+        let mut cache = ViewCache::default();
+        cache.refresh_sizes(tree, &all_open(tree), None);
+        cache.rematerialize(
+            tree,
+            &all_open(tree),
+            None,
+            tree.roots(),
+            0..tree.nodes.len(),
+        );
+        cache
+    }
+
+    #[test]
+    fn sibling_links_round_trip() {
+        let tree = fixture();
+        let cache = build_cache(&tree);
+        let n = &cache.nodes;
+
+        // Sibling pairs after full materialization (by VisIdx):
+        //   1: a  ↔ 4: b      (children of root)
+        //   2: aa ↔ 3: ab     (children of a)
+        assert_eq!(n[1].next_sibling, Some(VisIdx(4)));
+        assert_eq!(n[4].prev_sibling, Some(VisIdx(1)));
+        assert_eq!(n[2].next_sibling, Some(VisIdx(3)));
+        assert_eq!(n[3].prev_sibling, Some(VisIdx(2)));
+        assert_eq!(n[0].next_sibling, None);
+        assert_eq!(n[0].prev_sibling, None);
+        assert_eq!(n[5].next_sibling, None);
+
+        // Round-trip every link.
+        for (i, node) in n.iter().enumerate() {
+            if let Some(next) = node.next_sibling {
+                assert_eq!(n[next.0].prev_sibling, Some(VisIdx(i)));
+            }
+            if let Some(prev) = node.prev_sibling {
+                assert_eq!(n[prev.0].next_sibling, Some(VisIdx(i)));
+            }
+        }
+    }
+
+    #[test]
+    fn is_last_non_group_child_full_tree() {
+        let tree = fixture();
+        let cache = build_cache(&tree);
+        let n = &cache.nodes;
+        // full tree:
+        //
+        // root
+        // |- a
+        // |  |- aa
+        // |  `- ab
+        // `- b
+        //    `- bb
+        //
+        // last non-group children:
+        //
+        // root -> b
+        // a    -> ab
+        // b    -> bb
+        assert!(n[0].is_last_non_group_child);
+        assert!(!n[1].is_last_non_group_child);
+        assert!(!n[2].is_last_non_group_child);
+        assert!(n[3].is_last_non_group_child);
+        assert!(n[4].is_last_non_group_child);
+        assert!(n[5].is_last_non_group_child);
+    }
+
+    #[test]
+    fn is_last_non_group_child_reflects_full_tree_not_window() {
+        // full tree:
+        //
+        // root
+        // `- a
+        //    |- aa   <- in window
+        //    `- ab   <- outside window, but still the real last child
+        let tree = fixture();
+        let (_, nodes) = materialize(&tree, &all_open(&tree), 2, 1);
+        // emitted rows:
+        //
+        // root
+        // `- a
+        //    `- aa
+        let aa = nodes.iter().find(|n| n.id.0 == 2).unwrap();
+        assert!(!aa.is_last_non_group_child);
+        // The prefix-emitted `a` is also not last because root still has `b`.
+        let a = nodes.iter().find(|n| n.id.0 == 1).unwrap();
+        assert!(!a.is_last_non_group_child);
+    }
 }

--- a/src/ops/tree/tui/widget/view_cache.rs
+++ b/src/ops/tree/tui/widget/view_cache.rs
@@ -1,0 +1,363 @@
+use crate::core::{DependencyTree, NodeId};
+
+use super::state::{VirtualPos, VisIdx, VisibleNode};
+
+/// Cached materialization state for a single view (normal or search-filtered).
+#[derive(Debug, Default)]
+pub(super) struct ViewCache {
+    /// Materialized window of visible nodes around the viewport.
+    pub(super) nodes: Vec<VisibleNode>,
+    /// Last visible non-group child per parent, indexed by parent visible index.
+    pub(super) last_non_group_child: Vec<Option<VisIdx>>,
+    /// Memoized visible-subtree sizes indexed by NodeId.
+    pub(super) subtree_sizes: Vec<usize>,
+    /// Total number of virtual lines (sum of root subtree sizes).
+    pub(super) total_virtual_lines: usize,
+    /// Whether sibling links / last-child map need recomputation.
+    pub(super) metadata_dirty: bool,
+}
+
+impl ViewCache {
+    /// Clears all cached data, resetting to empty state.
+    pub(super) fn clear(&mut self) {
+        self.nodes.clear();
+        self.last_non_group_child.fill(None);
+        self.subtree_sizes.clear();
+        self.total_virtual_lines = 0;
+        self.metadata_dirty = false;
+    }
+
+    /// Applies a materialization result to this cache.
+    pub(super) fn apply_materialization(&mut self, result: MaterializeResult) {
+        self.nodes = result.nodes;
+        self.metadata_dirty = true;
+    }
+
+    /// Recomputes subtree sizes for the given filter.
+    pub(super) fn recompute_subtree_sizes(
+        &mut self,
+        tree: &DependencyTree,
+        open: &[bool],
+        filter: Option<&[bool]>,
+    ) {
+        self.total_virtual_lines =
+            compute_subtree_sizes(tree, open, filter, &mut self.subtree_sizes);
+    }
+
+    /// Ensures sibling links and last-child map are up to date.
+    pub(super) fn ensure_metadata(&mut self, tree: &DependencyTree) {
+        if !self.metadata_dirty || self.nodes.is_empty() {
+            return;
+        }
+        Self::populate_sibling_links(&mut self.nodes);
+        Self::populate_last_non_group_child_map(tree, &self.nodes, &mut self.last_non_group_child);
+        self.metadata_dirty = false;
+    }
+
+    /// Records, for each parent visible position, the last visible non-group child position.
+    fn populate_last_non_group_child_map(
+        tree: &DependencyTree,
+        visible_nodes: &[VisibleNode],
+        target: &mut Vec<Option<VisIdx>>,
+    ) {
+        target.clear();
+        target.resize(visible_nodes.len(), None);
+
+        for (vis_idx, node) in visible_nodes.iter().enumerate() {
+            let Some(tree_node) = tree.node(node.id) else {
+                continue;
+            };
+
+            if tree_node.is_group() {
+                continue;
+            }
+
+            if let Some(parent_vis_idx) = node.parent_vis_idx {
+                target[parent_vis_idx.0] = Some(VisIdx(vis_idx));
+            }
+        }
+    }
+
+    /// Links each visible node to its next and previous sibling (same parent).
+    fn populate_sibling_links(visible_nodes: &mut [VisibleNode]) {
+        let mut last_child_of: Vec<Option<VisIdx>> = vec![None; visible_nodes.len()];
+
+        for i in 0..visible_nodes.len() {
+            let Some(parent) = visible_nodes[i].parent_vis_idx else {
+                continue;
+            };
+
+            let current = VisIdx(i);
+            if let Some(prev) = last_child_of[parent.0] {
+                visible_nodes[prev.0].next_sibling = Some(current);
+                visible_nodes[i].prev_sibling = Some(prev);
+            }
+            last_child_of[parent.0] = Some(current);
+        }
+    }
+}
+
+// ── Materialization ─────────────────────────────────────────────────
+
+/// Output of windowed materialization.
+pub(super) struct MaterializeResult {
+    /// Materialized nodes: ancestor prefix + viewport window.
+    pub(super) nodes: Vec<VisibleNode>,
+}
+
+struct MaterializeCtx<'a> {
+    tree: &'a DependencyTree,
+    open: &'a [bool],
+    sizes: &'a [usize],
+    filter: Option<&'a [bool]>,
+    virtual_pos: usize,
+    window_start: usize,
+    window_end: usize,
+    /// Stack of ancestors on the current DFS path: (NodeId, depth, virtual_pos).
+    ancestor_stack: Vec<(NodeId, usize, usize)>,
+    /// Cycle guard: nodes currently on the DFS path. Mirrors `in_progress`
+    /// in `compute_size_recursive` so back-edges in cyclic dep graphs
+    /// (e.g. dev-dep cycles) are emitted as leaves rather than recursed into.
+    in_progress: Vec<bool>,
+    prefix_emitted: bool,
+    output: Vec<VisibleNode>,
+}
+
+impl MaterializeCtx<'_> {
+    fn materialize_node(&mut self, id: NodeId, depth: usize, parent_ancestor_idx: Option<usize>) {
+        let my_vpos = self.virtual_pos;
+        let subtree_size = self.sizes[id.0];
+
+        // Entirely before window — skip subtree
+        if my_vpos + subtree_size <= self.window_start {
+            self.virtual_pos += subtree_size;
+            return;
+        }
+
+        // Entirely past window — stop
+        if my_vpos >= self.window_end {
+            return;
+        }
+
+        // This node is in or overlaps the window.
+        self.virtual_pos += 1;
+
+        let in_window = my_vpos >= self.window_start;
+
+        if in_window {
+            // Emit ancestor prefix if this is the first in-window node.
+            if !self.prefix_emitted {
+                self.emit_ancestor_prefix();
+            }
+
+            let parent_vis_idx = if depth == 0 {
+                None
+            } else {
+                // Find the parent in the output buffer.
+                // The parent is the last ancestor_stack entry, which was either emitted
+                // as prefix or as a previous window node.
+                self.find_parent_vis_idx(parent_ancestor_idx)
+            };
+
+            self.output.push(VisibleNode {
+                id,
+                depth,
+                virtual_pos: VirtualPos(my_vpos),
+                parent_vis_idx,
+                next_sibling: None,
+                prev_sibling: None,
+            });
+        }
+
+        // Recurse into children if open. Skip recursion on a back-edge —
+        // a node already on the current DFS path is a cycle, and the size
+        // accounting in `compute_size_recursive` treats it as a leaf.
+        if self.open[id.0]
+            && !self.in_progress[id.0]
+            && let Some(node) = self.tree.node(id)
+        {
+            let my_ancestor_idx = self.ancestor_stack.len();
+            self.ancestor_stack.push((id, depth, my_vpos));
+            self.in_progress[id.0] = true;
+
+            for &child in node.children() {
+                if self.filter.is_some_and(|f| !f[child.0]) {
+                    continue;
+                }
+                if self.virtual_pos >= self.window_end {
+                    break;
+                }
+                let child_size = self.sizes[child.0];
+                if self.virtual_pos + child_size <= self.window_start {
+                    self.virtual_pos += child_size;
+                    continue;
+                }
+                self.materialize_node(child, depth + 1, Some(my_ancestor_idx));
+            }
+
+            self.in_progress[id.0] = false;
+            self.ancestor_stack.pop();
+        }
+    }
+
+    /// Emits ancestor prefix nodes for lineage/breadcrumb rendering.
+    fn emit_ancestor_prefix(&mut self) {
+        self.prefix_emitted = true;
+
+        if self.ancestor_stack.is_empty() {
+            return;
+        }
+
+        for i in 0..self.ancestor_stack.len() {
+            let (anc_id, anc_depth, anc_vpos) = self.ancestor_stack[i];
+
+            let parent_vis_idx = if anc_depth == 0 || i == 0 {
+                None
+            } else {
+                // Parent is the previous ancestor in the prefix.
+                Some(VisIdx(self.output.len() - 1))
+            };
+
+            self.output.push(VisibleNode {
+                id: anc_id,
+                depth: anc_depth,
+                virtual_pos: VirtualPos(anc_vpos),
+                parent_vis_idx,
+                next_sibling: None,
+                prev_sibling: None,
+            });
+        }
+    }
+
+    /// Finds the VisIdx of the parent node in the output buffer.
+    fn find_parent_vis_idx(&self, parent_ancestor_idx: Option<usize>) -> Option<VisIdx> {
+        let parent_ancestor_idx = parent_ancestor_idx?;
+        let (parent_id, _, parent_vpos) = self.ancestor_stack[parent_ancestor_idx];
+
+        // Search the output buffer for this parent.
+        // It's either in the prefix or was emitted as a window node.
+        // Search from the end since the parent was recently emitted.
+        self.output
+            .iter()
+            .rposition(|n| n.id == parent_id && n.virtual_pos == VirtualPos(parent_vpos))
+            .map(VisIdx)
+    }
+}
+
+/// Materializes a window of visible nodes around a viewport range.
+///
+/// The output contains an ancestor prefix (for lineage/breadcrumb rendering)
+/// followed by the viewport window nodes. Only nodes within `[window_start, window_end)`
+/// are emitted, plus ancestors of the first emitted node.
+pub(super) fn materialize_window(
+    tree: &DependencyTree,
+    open: &[bool],
+    sizes: &[usize],
+    filter: Option<&[bool]>,
+    roots: &[NodeId],
+    window_start: usize,
+    window_count: usize,
+) -> MaterializeResult {
+    let mut ctx = MaterializeCtx {
+        tree,
+        open,
+        sizes,
+        filter,
+        virtual_pos: 0,
+        window_start,
+        window_end: window_start + window_count,
+        ancestor_stack: Vec::with_capacity(64),
+        in_progress: vec![false; tree.nodes.len()],
+        prefix_emitted: false,
+        output: Vec::with_capacity(window_count + 64),
+    };
+
+    for &root in roots {
+        if filter.is_some_and(|f| !f[root.0]) {
+            continue;
+        }
+        if ctx.virtual_pos >= ctx.window_end {
+            break;
+        }
+        let root_size = sizes[root.0];
+        if ctx.virtual_pos + root_size <= ctx.window_start {
+            ctx.virtual_pos += root_size;
+            continue;
+        }
+        ctx.materialize_node(root, 0, None);
+    }
+
+    MaterializeResult { nodes: ctx.output }
+}
+
+// ── Subtree size computation ──��─────────────────────────────────────
+
+/// Computes memoized visible-subtree sizes for all nodes.
+///
+/// `subtree_size[id] = 1 + (if open[id]: Σ subtree_size[child])`.
+/// A `computed` guard prevents recomputing already-visited nodes (DAG memoization).
+/// An `in_progress` guard breaks hypothetical cycles by treating in-progress nodes as leaves.
+fn compute_subtree_sizes(
+    tree: &DependencyTree,
+    open: &[bool],
+    filter: Option<&[bool]>,
+    sizes: &mut Vec<usize>,
+) -> usize {
+    sizes.clear();
+    sizes.resize(tree.nodes.len(), 0);
+    let mut computed = vec![false; tree.nodes.len()];
+    let mut in_progress = vec![false; tree.nodes.len()];
+
+    let mut total = 0usize;
+    for &root in tree.roots() {
+        if filter.is_some_and(|f| !f[root.0]) {
+            continue;
+        }
+        total += compute_size_recursive(
+            tree,
+            open,
+            filter,
+            root,
+            sizes,
+            &mut computed,
+            &mut in_progress,
+        );
+    }
+    total
+}
+
+fn compute_size_recursive(
+    tree: &DependencyTree,
+    open: &[bool],
+    filter: Option<&[bool]>,
+    id: NodeId,
+    sizes: &mut [usize],
+    computed: &mut [bool],
+    in_progress: &mut [bool],
+) -> usize {
+    if in_progress[id.0] {
+        return 1; // cycle break
+    }
+    if computed[id.0] {
+        return sizes[id.0];
+    }
+
+    in_progress[id.0] = true;
+
+    let mut size: usize = 1;
+    if open[id.0]
+        && let Some(node) = tree.node(id)
+    {
+        for &child in node.children() {
+            if filter.is_some_and(|f| !f[child.0]) {
+                continue;
+            }
+            size += compute_size_recursive(tree, open, filter, child, sizes, computed, in_progress);
+        }
+    }
+
+    sizes[id.0] = size;
+    computed[id.0] = true;
+    in_progress[id.0] = false;
+    size
+}

--- a/src/ops/tree/tui/widget/viewport.rs
+++ b/src/ops/tree/tui/widget/viewport.rs
@@ -29,29 +29,55 @@ impl Viewport {
         }
     }
 
-    /// Centers the viewport on the given focus line, accounting for reserved lines.
-    pub fn center_on(
+    /// Scrolls the viewport so that `focus_line` (0-indexed) stays visible,
+    /// reusing the previous offset to keep the view stable.
+    ///
+    /// The returned `offset` may exceed `max_offset` — the render pipeline
+    /// calls [`clamp_offset`] after accounting for context/breadcrumb lines.
+    pub fn scroll_into_view(
         mut self,
         focus_line: usize,
         total_lines: usize,
         reserved_lines: usize,
+        prev_offset: usize,
     ) -> Self {
         if self.height > 0 && reserved_lines > 0 {
             self.height = self.height.saturating_sub(reserved_lines);
         }
-        if self.height > 0 {
-            if self.height == 0 {
-                self.offset = 0;
-                self.max_offset = 0;
-            } else {
-                let center_line = self.height.div_ceil(2);
-                let offset = focus_line.saturating_sub(center_line);
-                let max_offset = total_lines.saturating_sub(self.height);
+        if self.height == 0 {
+            self.offset = 0;
+            self.max_offset = 0;
+            return self;
+        }
 
-                self.offset = offset;
-                self.max_offset = max_offset;
+        self.max_offset = total_lines.saturating_sub(self.height);
+        let margin = (self.height / 4).max(1);
+
+        // Start from the previous offset.
+        let mut offset = prev_offset;
+
+        // Scroll down if the selection is too close to the bottom edge.
+        let bottom_threshold = offset + self.height.saturating_sub(margin);
+        if focus_line >= bottom_threshold {
+            offset = (focus_line + margin).saturating_sub(self.height);
+        }
+
+        // Scroll up if the selection is too close to the top edge.
+        let top_threshold = offset + margin.saturating_sub(1);
+        if focus_line < offset || (offset > 0 && focus_line <= top_threshold) {
+            offset = focus_line.saturating_sub(margin.saturating_sub(1));
+        }
+
+        // When offset > 0, context/ancestor lines will consume at least 1 row,
+        // reducing the usable content height. Re-check the bottom bound.
+        if offset > 0 {
+            let content_height = self.height.saturating_sub(1);
+            if content_height > 0 && focus_line >= offset + content_height {
+                offset = focus_line + 1 - content_height;
             }
         }
+
+        self.offset = offset;
         self
     }
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -2,7 +2,6 @@ use cargo_tree_tui::core::dependency::DependencyType;
 use cargo_tree_tui::core::{Dependency, DependencyGroup, DependencyNode, DependencyTree, NodeId};
 use cargo_tree_tui::ops::tree::tui::widget::render::RenderContext;
 use cargo_tree_tui::ops::tree::tui::widget::{TreeWidget, TreeWidgetState, TreeWidgetStyle};
-use compact_str::CompactString;
 use ratatui::Terminal;
 use ratatui::backend::TestBackend;
 use ratatui::layout::Rect;
@@ -22,16 +21,12 @@ pub struct TestNode {
 
 pub fn build_tree(nodes: &[TestNode]) -> DependencyTree {
     let mut arena = Vec::with_capacity(nodes.len());
-    let mut parents: Vec<Vec<NodeId>> = vec![Vec::new(); nodes.len()];
-    for (idx, node) in nodes.iter().enumerate() {
-        let children: Vec<NodeId> = node.children.iter().copied().map(NodeId).collect();
-        for child in &children {
-            parents[child.0].push(NodeId(idx));
-        }
+    for node in nodes {
+        let children = node.children.iter().copied().map(NodeId).collect();
         let node = match node.kind {
             TestNodeKind::Crate => DependencyNode::Crate(Dependency {
                 name: node.name.into(),
-                version: CompactString::const_new(""),
+                version: "".into(),
                 manifest_dir: None,
                 is_proc_macro: false,
                 children,
@@ -47,10 +42,19 @@ pub fn build_tree(nodes: &[TestNode]) -> DependencyTree {
         .filter_map(|(idx, node)| node.parent.is_none().then_some(NodeId(idx)))
         .collect();
 
+    // Build reverse parent map from children lists.
+    let mut parents = vec![Vec::new(); arena.len()];
+    for (idx, node) in arena.iter().enumerate() {
+        let parent_id = NodeId(idx);
+        for &child_id in node.children() {
+            parents[child_id.0].push(parent_id);
+        }
+    }
+
     DependencyTree {
         workspace_name: "workspace".into(),
-        nodes: arena,
         parents,
+        nodes: arena,
         roots,
     }
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -2,6 +2,7 @@ use cargo_tree_tui::core::dependency::DependencyType;
 use cargo_tree_tui::core::{Dependency, DependencyGroup, DependencyNode, DependencyTree, NodeId};
 use cargo_tree_tui::ops::tree::tui::widget::render::RenderContext;
 use cargo_tree_tui::ops::tree::tui::widget::{TreeWidget, TreeWidgetState, TreeWidgetStyle};
+use compact_str::CompactString;
 use ratatui::Terminal;
 use ratatui::backend::TestBackend;
 use ratatui::layout::Rect;
@@ -21,23 +22,21 @@ pub struct TestNode {
 
 pub fn build_tree(nodes: &[TestNode]) -> DependencyTree {
     let mut arena = Vec::with_capacity(nodes.len());
-    for node in nodes {
-        let parent = node.parent.map(NodeId);
-        let children = node.children.iter().copied().map(NodeId).collect();
+    let mut parents: Vec<Vec<NodeId>> = vec![Vec::new(); nodes.len()];
+    for (idx, node) in nodes.iter().enumerate() {
+        let children: Vec<NodeId> = node.children.iter().copied().map(NodeId).collect();
+        for child in &children {
+            parents[child.0].push(NodeId(idx));
+        }
         let node = match node.kind {
             TestNodeKind::Crate => DependencyNode::Crate(Dependency {
-                name: node.name.to_string(),
-                version: String::new(),
+                name: node.name.into(),
+                version: CompactString::const_new(""),
                 manifest_dir: None,
                 is_proc_macro: false,
-                parent,
                 children,
             }),
-            TestNodeKind::Group(kind) => DependencyNode::Group(DependencyGroup {
-                kind,
-                parent,
-                children,
-            }),
+            TestNodeKind::Group(kind) => DependencyNode::Group(DependencyGroup { kind, children }),
         };
         arena.push(node);
     }
@@ -49,13 +48,9 @@ pub fn build_tree(nodes: &[TestNode]) -> DependencyTree {
         .collect();
 
     DependencyTree {
-        workspace_name: "workspace".to_string(),
-        crate_nodes: arena
-            .iter()
-            .enumerate()
-            .filter_map(|(idx, node)| (!node.is_group()).then_some(NodeId(idx)))
-            .collect(),
+        workspace_name: "workspace".into(),
         nodes: arena,
+        parents,
         roots,
     }
 }

--- a/tests/dependency.rs
+++ b/tests/dependency.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use cargo_metadata::DependencyKind;
+use cargo::core::dependency::DepKind;
 use cargo_tree_tui::core::dependency::DependencyType;
 use cargo_tree_tui::core::{Dependency, DependencyGroup, DependencyNode, DependencyTree, NodeId};
 
@@ -301,24 +301,16 @@ fn display_name_for_crate_and_group() {
 }
 
 #[test]
-fn dependency_type_from_dependency_kind() {
+fn dependency_type_from_dep_kind() {
     assert_eq!(
-        DependencyType::try_from(DependencyKind::Normal),
-        Ok(DependencyType::Normal)
+        DependencyType::from(DepKind::Normal),
+        DependencyType::Normal
     );
     assert_eq!(
-        DependencyType::try_from(DependencyKind::Development),
-        Ok(DependencyType::Dev)
+        DependencyType::from(DepKind::Development),
+        DependencyType::Dev
     );
-    assert_eq!(
-        DependencyType::try_from(DependencyKind::Build),
-        Ok(DependencyType::Build)
-    );
-}
-
-#[test]
-fn dependency_type_unknown_kind_is_err() {
-    assert!(DependencyType::try_from(DependencyKind::Unknown).is_err());
+    assert_eq!(DependencyType::from(DepKind::Build), DependencyType::Build);
 }
 
 #[test]

--- a/tests/dependency.rs
+++ b/tests/dependency.rs
@@ -1,0 +1,340 @@
+use std::path::PathBuf;
+
+use cargo_metadata::DependencyKind;
+use cargo_tree_tui::core::dependency::DependencyType;
+use cargo_tree_tui::core::{Dependency, DependencyGroup, DependencyNode, DependencyTree, NodeId};
+
+fn project_manifest() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml")
+}
+
+#[test]
+fn load_returns_tree_for_own_manifest() {
+    let tree = DependencyTree::load(Some(project_manifest())).unwrap();
+    assert_eq!(tree.workspace_name, "cargo-tree-tui");
+}
+
+#[test]
+fn load_has_single_root() {
+    let tree = DependencyTree::load(Some(project_manifest())).unwrap();
+    assert_eq!(
+        tree.roots().len(),
+        1,
+        "single-crate workspace should have one root"
+    );
+}
+
+#[test]
+fn root_node_is_crate_with_correct_name() {
+    let tree = DependencyTree::load(Some(project_manifest())).unwrap();
+    let root_id = tree.roots()[0];
+    let root = tree.node(root_id).unwrap();
+
+    assert!(
+        matches!(root, DependencyNode::Crate(_)),
+        "root should be a Crate node"
+    );
+    assert_eq!(root.display_name(), "cargo-tree-tui");
+}
+
+#[test]
+fn root_has_children() {
+    let tree = DependencyTree::load(Some(project_manifest())).unwrap();
+    let root_id = tree.roots()[0];
+    let root = tree.node(root_id).unwrap();
+
+    assert!(
+        !root.children().is_empty(),
+        "root should have at least one child (this crate has dependencies)"
+    );
+}
+
+#[test]
+fn all_nodes_reachable_from_roots() {
+    let tree = DependencyTree::load(Some(project_manifest())).unwrap();
+
+    let mut visited = vec![false; tree.nodes.len()];
+    let mut stack: Vec<NodeId> = tree.roots().to_vec();
+
+    while let Some(id) = stack.pop() {
+        if visited[id.0] {
+            continue;
+        }
+        visited[id.0] = true;
+        if let Some(node) = tree.node(id) {
+            stack.extend_from_slice(node.children());
+        }
+    }
+
+    let reachable = visited.iter().filter(|&&v| v).count();
+    assert_eq!(
+        reachable,
+        tree.nodes.len(),
+        "every node in the arena should be reachable from the roots"
+    );
+}
+
+#[test]
+fn crate_nodes_excludes_groups() {
+    let tree = DependencyTree::load(Some(project_manifest())).unwrap();
+
+    for id in tree.crate_nodes() {
+        let node = tree.node(id).unwrap();
+        assert!(
+            !node.is_group(),
+            "crate_nodes should not contain group nodes"
+        );
+    }
+}
+
+#[test]
+fn crate_nodes_covers_all_crates() {
+    let tree = DependencyTree::load(Some(project_manifest())).unwrap();
+
+    let crate_count = tree
+        .nodes
+        .iter()
+        .filter(|n| matches!(n, DependencyNode::Crate(_)))
+        .count();
+    assert_eq!(
+        tree.crate_nodes().count(),
+        crate_count,
+        "crate_nodes should list every Crate node in the arena"
+    );
+}
+
+#[test]
+fn known_dependency_present() {
+    let tree = DependencyTree::load(Some(project_manifest())).unwrap();
+
+    let has_ratatui = tree.crate_nodes().any(|id| {
+        tree.node(id)
+            .map(|n| n.display_name() == "ratatui")
+            .unwrap_or(false)
+    });
+    assert!(has_ratatui, "ratatui should appear as a dependency");
+}
+
+#[test]
+fn parent_child_links_consistent() {
+    let tree = DependencyTree::load(Some(project_manifest())).unwrap();
+
+    for (idx, node) in tree.nodes.iter().enumerate() {
+        let node_id = NodeId(idx);
+        for &child_id in node.children() {
+            assert!(
+                tree.node(child_id).is_some(),
+                "child id {:?} should be valid",
+                child_id
+            );
+            assert!(
+                tree.parents[child_id.0].contains(&node_id),
+                "parents of child {:?} should include {:?}",
+                child_id,
+                node_id
+            );
+        }
+    }
+}
+
+#[test]
+fn root_nodes_have_no_parent() {
+    let tree = DependencyTree::load(Some(project_manifest())).unwrap();
+
+    for &root_id in tree.roots() {
+        assert!(
+            tree.parents[root_id.0].is_empty(),
+            "root node {:?} should have no parent",
+            root_id
+        );
+    }
+}
+
+#[test]
+fn group_nodes_have_valid_kind() {
+    let tree = DependencyTree::load(Some(project_manifest())).unwrap();
+
+    for (idx, node) in tree.nodes.iter().enumerate() {
+        if let DependencyNode::Group(group) = node {
+            // label() should return a non-empty string for any valid kind
+            assert!(!group.label().is_empty(), "group label should not be empty");
+            let group_id = NodeId(idx);
+            assert!(
+                !tree.parents[group_id.0].is_empty(),
+                "group nodes should always have a parent"
+            );
+        }
+    }
+}
+
+#[test]
+fn dev_dependencies_under_group() {
+    let tree = DependencyTree::load(Some(project_manifest())).unwrap();
+
+    // pretty_assertions is a dev dep of this crate
+    let pa_id = tree
+        .crate_nodes()
+        .find(|&id| {
+            tree.node(id)
+                .map(|n| n.display_name() == "pretty_assertions")
+                .unwrap_or(false)
+        })
+        .expect("pretty_assertions should be in the tree as a dev dependency");
+
+    let parents = &tree.parents[pa_id.0];
+    assert!(
+        !parents.is_empty(),
+        "pretty_assertions should have at least one parent"
+    );
+    let under_dev_group = parents.iter().any(|&parent_id| {
+        tree.node(parent_id)
+            .and_then(|n| n.as_group())
+            .map(|g| g.kind == DependencyType::Dev)
+            .unwrap_or(false)
+    });
+    assert!(
+        under_dev_group,
+        "pretty_assertions should be nested under a [dev-dependencies] group"
+    );
+}
+
+#[test]
+fn dedup_each_crate_version_appears_once() {
+    let tree = DependencyTree::load(Some(project_manifest())).unwrap();
+
+    // Group crate node ids by (name, version) — the logical package identity.
+    let mut by_pkg: std::collections::HashMap<(&str, &str), Vec<NodeId>> =
+        std::collections::HashMap::new();
+
+    for id in tree.crate_nodes() {
+        let dep = tree.node(id).unwrap().as_dependency().unwrap();
+        by_pkg
+            .entry((&dep.name, &dep.version))
+            .or_default()
+            .push(id);
+    }
+
+    for ((name, version), ids) in &by_pkg {
+        assert_eq!(
+            ids.len(),
+            1,
+            "'{name} v{version}' should appear exactly once in the \
+             deduplicated arena, but found {} occurrences",
+            ids.len()
+        );
+    }
+}
+
+#[test]
+fn dedup_shared_child_referenced_by_multiple_parents() {
+    let tree = DependencyTree::load(Some(project_manifest())).unwrap();
+
+    // Find crates that have more than one parent (shared children).
+    let multi_parent: Vec<NodeId> = tree
+        .crate_nodes()
+        .filter(|id| tree.parents[id.0].len() > 1)
+        .collect();
+
+    assert!(
+        !multi_parent.is_empty(),
+        "at least one crate should be referenced by multiple parents \
+         (shared subtree via dedup)"
+    );
+
+    // Each shared crate should have a single NodeId referenced from
+    // multiple parent children lists.
+    for &id in &multi_parent {
+        for &parent_id in &tree.parents[id.0] {
+            let parent = tree.node(parent_id).unwrap();
+            assert!(
+                parent.children().contains(&id),
+                "parent {:?} claims to be parent of {:?} but doesn't \
+                 list it as a child",
+                parent_id,
+                id
+            );
+        }
+    }
+}
+
+#[test]
+fn as_dependency_returns_some_for_crate() {
+    let dep = DependencyNode::Crate(Dependency {
+        name: "foo".into(),
+        version: "1.0.0".into(),
+        manifest_dir: None,
+        is_proc_macro: false,
+        children: vec![],
+    });
+    assert!(dep.as_dependency().is_some());
+    assert!(dep.as_group().is_none());
+    assert!(!dep.is_group());
+}
+
+#[test]
+fn as_group_returns_some_for_group() {
+    let group = DependencyNode::Group(DependencyGroup {
+        kind: DependencyType::Dev,
+        children: vec![],
+    });
+    assert!(group.as_group().is_some());
+    assert!(group.as_dependency().is_none());
+    assert!(group.is_group());
+}
+
+#[test]
+fn display_name_for_crate_and_group() {
+    let crate_node = DependencyNode::Crate(Dependency {
+        name: "serde".into(),
+        version: "1.0.0".into(),
+        manifest_dir: None,
+        is_proc_macro: false,
+        children: vec![NodeId(1)],
+    });
+    assert_eq!(crate_node.display_name(), "serde");
+
+    let group_node = DependencyNode::Group(DependencyGroup {
+        kind: DependencyType::Build,
+        children: vec![],
+    });
+    assert_eq!(group_node.display_name(), "[build-dependencies]");
+}
+
+#[test]
+fn dependency_type_from_dependency_kind() {
+    assert_eq!(
+        DependencyType::try_from(DependencyKind::Normal),
+        Ok(DependencyType::Normal)
+    );
+    assert_eq!(
+        DependencyType::try_from(DependencyKind::Development),
+        Ok(DependencyType::Dev)
+    );
+    assert_eq!(
+        DependencyType::try_from(DependencyKind::Build),
+        Ok(DependencyType::Build)
+    );
+}
+
+#[test]
+fn dependency_type_unknown_kind_is_err() {
+    assert!(DependencyType::try_from(DependencyKind::Unknown).is_err());
+}
+
+#[test]
+fn dependency_type_labels() {
+    assert_eq!(DependencyType::Normal.label(), "[dependencies]");
+    assert_eq!(DependencyType::Dev.label(), "[dev-dependencies]");
+    assert_eq!(DependencyType::Build.label(), "[build-dependencies]");
+}
+
+#[test]
+fn dependency_type_styles_are_distinct() {
+    let normal = DependencyType::Normal.style();
+    let dev = DependencyType::Dev.style();
+    let build = DependencyType::Build.style();
+
+    assert_ne!(normal, dev);
+    assert_ne!(normal, build);
+    assert_ne!(dev, build);
+}

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -634,7 +634,7 @@ fn large_dag_no_oom() {
     let b_children: Vec<NodeId> = (11..=20).map(NodeId).collect();
     for i in 0..10 {
         arena.push(DependencyNode::Crate(Dependency {
-            name: format!("a{i}").into(),
+            name: format!("a{i}"),
             version: "0.1.0".into(),
             manifest_dir: None,
             is_proc_macro: false,
@@ -645,7 +645,7 @@ fn large_dag_no_oom() {
     let c_children: Vec<NodeId> = (21..=30).map(NodeId).collect();
     for i in 0..10 {
         arena.push(DependencyNode::Crate(Dependency {
-            name: format!("b{i}").into(),
+            name: format!("b{i}"),
             version: "0.1.0".into(),
             manifest_dir: None,
             is_proc_macro: false,
@@ -655,7 +655,7 @@ fn large_dag_no_oom() {
 
     for i in 0..10 {
         arena.push(DependencyNode::Crate(Dependency {
-            name: format!("c{i}").into(),
+            name: format!("c{i}"),
             version: "0.1.0".into(),
             manifest_dir: None,
             is_proc_macro: false,

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -311,7 +311,7 @@ fn breadcrumb_when_scrolled() {
     let tree = build_tree(&nodes);
     let mut state = TreeWidgetState::default();
     state.expand_all(&tree);
-    state.selected = Some(NodeId(7));
+    state.set_selected_node_id(&tree, NodeId(7));
 
     let area = Rect {
         x: 0,
@@ -338,7 +338,7 @@ root → a → b → c → d → e → f → g
         height: 5,
     };
 
-    state.selected = Some(NodeId(7));
+    state.set_selected_node_id(&tree, NodeId(7));
 
     let expected = r#"
 root
@@ -396,7 +396,7 @@ fn context_bar_when_scrolled() {
     let tree = build_tree(&nodes);
     let mut state = TreeWidgetState::default();
     state.expand_all(&tree);
-    state.selected = Some(NodeId(5));
+    state.set_selected_node_id(&tree, NodeId(5));
 
     let area = Rect {
         x: 0,
@@ -416,4 +416,370 @@ root → a → b → … → e
 
     let output = render_tree_widget(&tree, &mut state, area);
     assert_eq!(expected.trim(), output.trim());
+}
+
+// ── Virtual flattening / windowed materialization tests ─────────────
+
+/// A DAG with shared subtrees: root -> {a, b}, a -> c, b -> c, c -> d.
+/// With expand_all, `c`'s subtree is counted under both `a` and `b`.
+#[test]
+fn dag_shared_subtree_expand_all() {
+    let nodes = [
+        TestNode {
+            name: "root",
+            parent: None,
+            children: &[1, 2],
+            kind: TestNodeKind::Crate,
+        },
+        TestNode {
+            name: "a",
+            parent: Some(0),
+            children: &[3],
+            kind: TestNodeKind::Crate,
+        },
+        TestNode {
+            name: "b",
+            parent: Some(0),
+            children: &[3],
+            kind: TestNodeKind::Crate,
+        },
+        TestNode {
+            name: "c",
+            parent: Some(1),
+            children: &[4],
+            kind: TestNodeKind::Crate,
+        },
+        TestNode {
+            name: "d",
+            parent: Some(3),
+            children: &[],
+            kind: TestNodeKind::Crate,
+        },
+    ];
+
+    let tree = build_tree(&nodes);
+    let mut state = TreeWidgetState::default();
+    state.expand_all(&tree);
+
+    // root(1) + a(1) + c(1) + d(1) + b(1) + c(1) + d(1) = 7
+    assert_eq!(state.total_lines(&tree), 7);
+}
+
+/// Expand-all on a DAG renders shared subtrees under each parent.
+#[test]
+fn dag_shared_subtree_renders() {
+    let nodes = [
+        TestNode {
+            name: "root",
+            parent: None,
+            children: &[1, 2],
+            kind: TestNodeKind::Crate,
+        },
+        TestNode {
+            name: "a",
+            parent: Some(0),
+            children: &[3],
+            kind: TestNodeKind::Crate,
+        },
+        TestNode {
+            name: "b",
+            parent: Some(0),
+            children: &[3],
+            kind: TestNodeKind::Crate,
+        },
+        TestNode {
+            name: "c",
+            parent: Some(1),
+            children: &[4],
+            kind: TestNodeKind::Crate,
+        },
+        TestNode {
+            name: "d",
+            parent: Some(3),
+            children: &[],
+            kind: TestNodeKind::Crate,
+        },
+    ];
+
+    let tree = build_tree(&nodes);
+    let tree_str = render_tree_context(&tree);
+    let expected = r#"
+root
+├──▾ a
+│  └──▾ c
+│     └──• d
+└──▾ b
+   └──▾ c
+      └──• d
+"#;
+
+    assert_eq!(expected.trim(), tree_str.trim());
+}
+
+/// Navigation through a DAG: select_next walks all virtual positions in DFS order.
+#[test]
+fn dag_navigation_select_next() {
+    let nodes = [
+        TestNode {
+            name: "root",
+            parent: None,
+            children: &[1, 2],
+            kind: TestNodeKind::Crate,
+        },
+        TestNode {
+            name: "a",
+            parent: Some(0),
+            children: &[3],
+            kind: TestNodeKind::Crate,
+        },
+        TestNode {
+            name: "b",
+            parent: Some(0),
+            children: &[3],
+            kind: TestNodeKind::Crate,
+        },
+        TestNode {
+            name: "c",
+            parent: Some(1),
+            children: &[4],
+            kind: TestNodeKind::Crate,
+        },
+        TestNode {
+            name: "d",
+            parent: Some(3),
+            children: &[],
+            kind: TestNodeKind::Crate,
+        },
+    ];
+
+    let tree = build_tree(&nodes);
+    let mut state = TreeWidgetState::default();
+    state.expand_all(&tree);
+
+    let mut visited = Vec::new();
+    for _ in 0..7 {
+        state.ensure_visible_nodes(&tree);
+        let node_id = state.selected_node_id().unwrap();
+        visited.push(tree.node(node_id).unwrap().display_name().to_string());
+        state.select_next(&tree);
+    }
+
+    assert_eq!(visited, vec!["root", "a", "c", "d", "b", "c", "d"]);
+}
+
+/// Collapse and expand update total_lines correctly.
+#[test]
+fn collapse_expand_virtual_pos() {
+    let nodes = [
+        TestNode {
+            name: "root",
+            parent: None,
+            children: &[1, 2],
+            kind: TestNodeKind::Crate,
+        },
+        TestNode {
+            name: "a",
+            parent: Some(0),
+            children: &[3],
+            kind: TestNodeKind::Crate,
+        },
+        TestNode {
+            name: "b",
+            parent: Some(0),
+            children: &[],
+            kind: TestNodeKind::Crate,
+        },
+        TestNode {
+            name: "c",
+            parent: Some(1),
+            children: &[],
+            kind: TestNodeKind::Crate,
+        },
+    ];
+
+    let tree = build_tree(&nodes);
+    let mut state = TreeWidgetState::default();
+    state.expand_all(&tree);
+    assert_eq!(state.total_lines(&tree), 4);
+
+    // Select "a" and collapse it.
+    state.select_next(&tree);
+    state.ensure_visible_nodes(&tree);
+    assert_eq!(state.selected_node_id().map(|id| id.0), Some(1));
+    state.collapse(&tree);
+    assert_eq!(state.total_lines(&tree), 3); // root, a(collapsed), b
+
+    // Expand again.
+    state.expand(&tree);
+    assert_eq!(state.total_lines(&tree), 4);
+}
+
+/// Large DAG with shared subtrees doesn't OOM or panic.
+#[test]
+fn large_dag_no_oom() {
+    use cargo_tree_tui::core::{Dependency, DependencyNode, DependencyTree};
+
+    // root -> a0..a9 (shared b children), each bi -> c0..c9 (shared)
+    let mut arena = Vec::new();
+
+    let root_children: Vec<NodeId> = (1..=10).map(NodeId).collect();
+    arena.push(DependencyNode::Crate(Dependency {
+        name: "root".into(),
+        version: "0.1.0".into(),
+        manifest_dir: None,
+        is_proc_macro: false,
+        children: root_children,
+    }));
+
+    let b_children: Vec<NodeId> = (11..=20).map(NodeId).collect();
+    for i in 0..10 {
+        arena.push(DependencyNode::Crate(Dependency {
+            name: format!("a{i}").into(),
+            version: "0.1.0".into(),
+            manifest_dir: None,
+            is_proc_macro: false,
+            children: b_children.clone(),
+        }));
+    }
+
+    let c_children: Vec<NodeId> = (21..=30).map(NodeId).collect();
+    for i in 0..10 {
+        arena.push(DependencyNode::Crate(Dependency {
+            name: format!("b{i}").into(),
+            version: "0.1.0".into(),
+            manifest_dir: None,
+            is_proc_macro: false,
+            children: c_children.clone(),
+        }));
+    }
+
+    for i in 0..10 {
+        arena.push(DependencyNode::Crate(Dependency {
+            name: format!("c{i}").into(),
+            version: "0.1.0".into(),
+            manifest_dir: None,
+            is_proc_macro: false,
+            children: Vec::new(),
+        }));
+    }
+
+    let mut parents = vec![Vec::new(); arena.len()];
+    for (idx, node) in arena.iter().enumerate() {
+        for &child in node.children() {
+            parents[child.0].push(NodeId(idx));
+        }
+    }
+
+    let tree = DependencyTree {
+        workspace_name: "dag-test".into(),
+        parents,
+        nodes: arena,
+        roots: vec![NodeId(0)],
+    };
+
+    let mut state = TreeWidgetState::default();
+    state.expand_all(&tree);
+
+    // 1 + 10*(1 + 10*(1 + 10)) = 1 + 10*111 = 1111
+    assert_eq!(state.total_lines(&tree), 1111);
+
+    for _ in 0..100 {
+        state.select_next(&tree);
+    }
+    state.ensure_visible_nodes(&tree);
+    assert!(state.selected_node_id().is_some());
+}
+
+/// set_selected_node_id locates a node by its first virtual position.
+#[test]
+fn set_selected_node_id_in_dag() {
+    let nodes = [
+        TestNode {
+            name: "root",
+            parent: None,
+            children: &[1, 2],
+            kind: TestNodeKind::Crate,
+        },
+        TestNode {
+            name: "a",
+            parent: Some(0),
+            children: &[3],
+            kind: TestNodeKind::Crate,
+        },
+        TestNode {
+            name: "b",
+            parent: Some(0),
+            children: &[3],
+            kind: TestNodeKind::Crate,
+        },
+        TestNode {
+            name: "c",
+            parent: Some(1),
+            children: &[],
+            kind: TestNodeKind::Crate,
+        },
+    ];
+
+    let tree = build_tree(&nodes);
+    let mut state = TreeWidgetState::default();
+    state.expand_all(&tree);
+
+    state.set_selected_node_id(&tree, NodeId(2));
+    state.ensure_visible_nodes(&tree);
+    assert_eq!(state.selected_node_id().map(|id| id.0), Some(2));
+
+    state.set_selected_node_id(&tree, NodeId(3));
+    state.ensure_visible_nodes(&tree);
+    assert_eq!(state.selected_node_id().map(|id| id.0), Some(3));
+}
+
+/// A cyclic dep graph (a -> b -> a) must yield a finite, terminating
+/// view at the widget layer. Cargo permits cycles via dev-dependencies,
+/// so the resolve graph fed into [`DependencyTree`] can legitimately
+/// contain them. Without cycle breaking in `compute_subtree_sizes`,
+/// `total_lines` would diverge; without bounding in materialization,
+/// `expand_all` + render would loop forever.
+#[test]
+fn cyclic_tree_view_is_finite() {
+    let nodes = [
+        TestNode {
+            name: "a",
+            parent: None,
+            children: &[1],
+            kind: TestNodeKind::Crate,
+        },
+        TestNode {
+            name: "b",
+            parent: Some(0),
+            children: &[0],
+            kind: TestNodeKind::Crate,
+        },
+    ];
+
+    let tree = build_tree(&nodes);
+    let mut state = TreeWidgetState::default();
+    state.expand_all(&tree);
+
+    // The cycle breaker in `compute_subtree_sizes` treats the back-edge
+    // as a leaf, so the visible tree unrolls to exactly:
+    //   a            (size 1 + size(b) = 3)
+    //   └─ b         (size 1 + size(a as leaf) = 2)
+    //      └─ a      (cycle break, counted as 1)
+    assert_eq!(state.total_lines(&tree), 3);
+
+    // Render the materialized window: the cyclic tree must unroll once,
+    // then stop on the back-edge.
+    let area = Rect {
+        x: 0,
+        y: 0,
+        width: 40,
+        height: 10,
+    };
+    let rendered = render_tree_widget(&tree, &mut state, area);
+    let tree_rows: Vec<&str> = rendered.lines().take(3).collect();
+    assert_eq!(
+        tree_rows,
+        vec!["a", "└──▾ b", "   └──▾ a"],
+        "full render:\n{rendered}"
+    );
 }


### PR DESCRIPTION
extracted the dep loading approach from #69 

~~due to aforementioned structural changes to `Dependency` and friends, the impact on the widget layer is pretty substantial. this PR avoids all that by converting the new `DependencyTree2` into the old `DependencyTree`. this implies there are zero performance benefits since anything gained is lost by expanding the old tree structure.~~


closes #37
closes #44
closes #58
